### PR TITLE
Add LHC token and distributor contract for patient rewards

### DIFF
--- a/packages/smart-contracts/contracts/lhctoken.rs
+++ b/packages/smart-contracts/contracts/lhctoken.rs
@@ -1,0 +1,47 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, token, Address, Env, String};
+
+pub enum DataKey {
+    Admin,
+    Token,
+}
+
+#[contract]
+pub struct Distributor;
+
+#[contractimpl]
+impl Distributor {
+
+    pub fn initialize(env: Env, admin: Address, token: Address) {
+    
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("Distributor has already been initialized");
+        }
+        
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::Token, &token);
+    }
+
+    pub fn reward_patient(env: Env, patient: Address, amount: i128) {
+    
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        admin.require_auth();
+
+    
+        if amount <= 0 {
+            panic!("Reward amount must be positive");
+        }
+        
+        let token_address: Address = env.storage().instance().get(&DataKey::Token).unwrap();
+        
+        let token_client = token::Client::new(&env, &token_address);
+    
+        let contract_address = env.current_contract_address();
+        token_client.transfer(&contract_address, &patient, &amount);
+        
+        env.events().publish(
+            (String::from_str(&env, "reward"), admin),
+            (patient, amount),
+        );
+    }
+}


### PR DESCRIPTION
This PR introduces the LumenHealth Credit (LHC) token to support a micro-economy within the app. It includes deployment of a standard Stellar Asset contract to create the LHC token, as well as a dedicated distributor contract responsible for managing its distribution. The distributor exposes a reward_patient(patient_address, amount) function that allows the clinic admin to send LHC tokens directly to patients as rewards. Additionally, the existing Per-Service Payment Contract has been updated to accept LHC as a valid payment method alongside XLM. This sets the foundation for token-based interactions and incentives within the LumenHealth ecosystem.

closes #34 