### PR TITLE
feat(smart-contracts): implement Escrow contract with deposit

### DIFF
--- a/packages/smart-contracts/contracts/escrow.rs
+++ b/packages/smart-contracts/contracts/escrow.rs
@@ -1,0 +1,166 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, token, Address, Env, String, Val, Vec};
+
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum Status {
+    AwaitingDeposit = 0, 
+    Funded = 1,          
+    Released = 2,        
+    Refunded = 3,        
+}
+
+
+pub enum DataKey {
+    Patient,
+    Specialist,
+    Arbiter,
+    Token,
+    Amount,
+    Status,
+}
+
+#[contract]
+pub struct EscrowContract;
+
+#[contractimpl]
+impl EscrowContract {
+    
+    
+    
+    
+    pub fn initialize(
+        env: Env,
+        patient: Address,
+        specialist: Address,
+        arbiter: Address,
+        token: Address,
+        amount: i128,
+    ) {
+        if env.storage().instance().has(&DataKey::Status) {
+            panic!("Contract has already been initialized");
+        }
+        if amount <= 0 {
+            panic!("Amount must be positive");
+        }
+
+        env.storage().instance().set(&DataKey::Patient, &patient);
+        env.storage().instance().set(&DataKey::Specialist, &specialist);
+        env.storage().instance().set(&DataKey::Arbiter, &arbiter);
+        env.storage().instance().set(&DataKey::Token, &token);
+        env.storage().instance().set(&DataKey::Amount, &amount);
+        env.storage().instance().set(&DataKey::Status, &Status::AwaitingDeposit);
+    }
+
+    
+    
+    
+    pub fn deposit(env: Env, from: Address) {
+        
+        from.require_auth();
+
+        
+        let patient: Address = env.storage().instance().get(&DataKey::Patient).unwrap();
+        if from != patient {
+            panic!("Only the patient can deposit funds");
+        }
+
+        
+        let status: Status = env.storage().instance().get(&DataKey::Status).unwrap();
+        if status != Status::AwaitingDeposit {
+            panic!("Contract is not awaiting deposit");
+        }
+
+        
+        let token_id: Address = env.storage().instance().get(&DataKey::Token).unwrap();
+        let amount: i128 = env.storage().instance().get(&DataKey::Amount).unwrap();
+        let token_client = token::Client::new(&env, &token_id);
+        token_client.transfer(&from, &env.current_contract_address(), &amount);
+
+        
+        env.storage().instance().set(&DataKey::Status, &Status::Funded);
+        env.events().publish((Symbol::new(&env, "deposit"),), (patient, amount));
+    }
+
+    
+    
+    
+    pub fn request_release(env: Env) {
+        let specialist: Address = env.storage().instance().get(&DataKey::Specialist).unwrap();
+        specialist.require_auth();
+
+        let status: Status = env.storage().instance().get(&DataKey::Status).unwrap();
+        if status != Status::Funded {
+            panic!("Contract is not in a funded state");
+        }
+        
+        env.events().publish((Symbol::new(&env, "request_release"),), (specialist,));
+    }
+
+    
+    pub fn confirm_release(env: Env) {
+        let patient: Address = env.storage().instance().get(&DataKey::Patient).unwrap();
+        patient.require_auth();
+
+        let status: Status = env.storage().instance().get(&DataKey::Status).unwrap();
+        if status != Status::Funded {
+            panic!("Contract is not in a funded state");
+        }
+
+        
+        Self::internal_release(&env);
+    }
+
+    
+    pub fn force_release(env: Env) {
+        let arbiter: Address = env.storage().instance().get(&DataKey::Arbiter).unwrap();
+        arbiter.require_auth();
+
+        let status: Status = env.storage().instance().get(&DataKey::Status).unwrap();
+        if status != Status::Funded {
+            panic!("Contract is not in a funded state");
+        }
+        
+        
+        Self::internal_release(&env);
+    }
+
+    
+    pub fn force_refund(env: Env) {
+        let arbiter: Address = env.storage().instance().get(&DataKey::Arbiter).unwrap();
+        arbiter.require_auth();
+        
+        let status: Status = env.storage().instance().get(&DataKey::Status).unwrap();
+        if status != Status::Funded {
+            panic!("Contract is not in a funded state");
+        }
+
+        let token_id: Address = env.storage().instance().get(&DataKey::Token).unwrap();
+        let amount: i128 = env.storage().instance().get(&DataKey::Amount).unwrap();
+        let patient: Address = env.storage().instance().get(&DataKey::Patient).unwrap();
+        let token_client = token::Client::new(&env, &token_id);
+
+        
+        token_client.transfer(&env.current_contract_address(), &patient, &amount);
+
+        
+        env.storage().instance().set(&DataKey::Status, &Status::Refunded);
+        env.events().publish((Symbol::new(&env, "refund"),), (arbiter, patient, amount));
+    }
+    
+    
+    fn internal_release(env: &Env) {
+        let token_id: Address = env.storage().instance().get(&DataKey::Token).unwrap();
+        let amount: i128 = env.storage().instance().get(&DataKey::Amount).unwrap();
+        let specialist: Address = env.storage().instance().get(&DataKey::Specialist).unwrap();
+        let token_client = token::Client::new(env, &token_id);
+
+        
+        token_client.transfer(&env.current_contract_address(), &specialist, &amount);
+
+        
+        env.storage().instance().set(&DataKey::Status, &Status::Released);
+        env.events().publish((Symbol::new(&env, "release"),), (specialist, amount));
+    }
+}


### PR DESCRIPTION
To support trusted payments in specialist referrals, this PR introduces an escrow smart contract that securely holds patient funds until the service is confirmed. Each contract is initialized with the patient, specialist, and optionally an arbiter (such as a clinic). After the specialist delivers the service, they may request a release of funds, which the patient must confirm. In case of disputes, the arbiter can enforce a resolution by releasing or refunding the funds. The contract is built as a simple state machine with multi-party authorization to ensure fairness.

closes #33 