### PR TITLE
Feat: Platform Wallet Service

### DIFF
--- a/apps/stellar-service/src/index.ts
+++ b/apps/stellar-service/src/index.ts
@@ -1,22 +1,24 @@
-import { config, getServerPublicKey, StellarNetwork } from './config';
+import { PlatformWalletService } from "./services/wallet.service";
 
-const startStellarService = async () => {
-  console.log('🚀 Stellar Service Starting...');
-  console.log(`🌍 Network: ${config.network}`);
+const run = async () => {
+  console.log("🚀 Starting Stellar Service Health Check...");
+  
+  const wallet = new PlatformWalletService();
 
   try {
-    const publicKey = getServerPublicKey();
-    console.log(`🔑 Server Wallet: ${publicKey}`);
+    const publicKey = wallet.getPublicKey();
+    console.log(`Checking balance for: ${publicKey}`);
 
-    if (config.network === StellarNetwork.TESTNET) {
-      console.log('🧪 Running in Test Mode');
+    const balance = await wallet.getNativeBalance();
+    console.log(`✅ Success! Balance: ${balance} XLM`);
+    
+    if (parseFloat(balance) < 5) {
+      console.warn("⚠️ Warning: Low balance. Please fund your testnet account.");
     }
 
-    console.log('✅ Service Initialized Successfully');
-  } catch (error) {
-    console.error('❌ Startup Failed:', error);
-    process.exit(1);
+  } catch (error: any) {
+    console.error("❌ Failed:", error.message);
   }
 };
 
-startStellarService();
+run();

--- a/apps/stellar-service/src/services/wallet.service.ts
+++ b/apps/stellar-service/src/services/wallet.service.ts
@@ -1,0 +1,69 @@
+import { Horizon, Keypair } from "@stellar/stellar-sdk";
+import { config } from "@lumen/config";
+
+export interface WalletBalance {
+  asset_type: string;
+  balance: string;
+}
+
+export class PlatformWalletService {
+  private server: Horizon.Server;
+  private keypair: Keypair | null = null;
+
+  constructor() {
+    // 1. Connect to the network defined in our shared config
+    this.server = new Horizon.Server(config.stellar.horizonUrl);
+
+    // 2. Load the Platform Keys (Safe loading)
+    if (config.stellar.platformSecretKey) {
+      try {
+        this.keypair = Keypair.fromSecret(config.stellar.platformSecretKey);
+        // Security Log (Public Key ONLY)
+        console.log(`🔐 Wallet Service Initialized for: ${this.keypair.publicKey()}`);
+      } catch (error) {
+        console.error("❌ Invalid Stellar Secret Key provided in .env");
+      }
+    } else {
+      console.warn("⚠️ No Platform Wallet Secret Key found. Wallet features will be disabled.");
+    }
+  }
+
+  /**
+   * Fetches the full account details from the Stellar Network.
+   * Useful for checking sequence numbers and all balances.
+   */
+  async getAccountDetails() {
+    if (!this.keypair) {
+      throw new Error("Wallet not configured. Cannot fetch details.");
+    }
+
+    try {
+      const account = await this.server.loadAccount(this.keypair.publicKey());
+      return account;
+    } catch (error: any) {
+      // Handle "Account Not Found" (Common on Testnet if not funded)
+      if (error.response && error.response.status === 404) {
+        throw new Error("Account not found on network. Please fund this wallet using the Friendbot.");
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Helper to get just the Native (XLM) balance.
+   */
+  async getNativeBalance(): Promise<string> {
+    const account = await this.getAccountDetails();
+    
+    // Find the "native" (XLM) balance entry
+    const native = account.balances.find((b) => b.asset_type === "native");
+    return native ? native.balance : "0.0000000";
+  }
+
+  /**
+   * Returns the Public Key (Safe to share)
+   */
+  getPublicKey(): string {
+    return this.keypair ? this.keypair.publicKey() : "";
+  }
+}


### PR DESCRIPTION
### Feature: Platform Wallet Service 

This PR introduces a service for managing the platform’s own Stellar wallet (the receiving account).

**What’s included**

* Adds a `PlatformWalletService` in
  `apps/stellar-service/src/services/wallet.service.ts`
* Initializes a Stellar SDK `Server` using shared configuration
* Implements `getAccountDetails()` to fetch the platform account from Horizon
* Handles **Account Not Found** errors gracefully (common on unfunded Testnet accounts)

closes #56
