### PR TITLE
Feature: Create Payment Record Data Model

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -2,11 +2,15 @@ import express from 'express';
 import cors from 'cors';
 import { config } from '@lumen/config';
 import { connectDB } from './config/db';
+import { paymentRoutes } from './modules/payments/payments.controller';
 
 const app = express();
 
 app.use(cors());
 app.use(express.json());
+
+app.use("/api/v1/payments", paymentRoutes);
+
 
 app.get('/health', (req, res) => {
   res.json({ status: 'ok', timestamp: new Date() });

--- a/apps/api/src/modules/payments/intent.service.ts
+++ b/apps/api/src/modules/payments/intent.service.ts
@@ -1,0 +1,49 @@
+import { config } from "@lumen/config";
+import crypto from "crypto";
+
+export interface PaymentIntent {
+  intentId: string;       // Internal System ID (UUID)
+  destination: string;    // The Platform's Wallet Address
+  amount: string;         // Amount to pay (e.g., "100")
+  asset: string;          // "XLM" or "USDC"
+  memo: string;           // The unique locking mechanism (Hash)
+  memoType: "hash";       // Stellar requires us to specify the type
+  expiresAt: Date;        // When this quote expires
+}
+
+export class PaymentIntentService {
+  /**
+   * Generates a payment instruction for a clinic.
+   * This does NOT charge them yet; it just creates the "invoice".
+   */
+  static createIntent(clinicId: string, amount: string): PaymentIntent {
+    if (!config.stellar.platformPublicKey) {
+      throw new Error("❌ Platform Wallet not configured. Cannot accept payments.");
+    }
+
+    // 1. Generate a unique reference ID for our system
+    const intentId = crypto.randomUUID();
+
+    // 2. Create a deterministic Memo Hash from the Intent ID
+    // We strip the hyphens from the UUID to make it cleaner, 
+    // or just hash the UUID to ensure it fits perfectly in 32 bytes.
+    const memoHash = crypto
+      .createHash("sha256")
+      .update(intentId + clinicId) // Bind it to the clinic for extra safety
+      .digest("hex");
+
+    // 3. Set Expiry (e.g., 60 minutes from now)
+    const expiresAt = new Date();
+    expiresAt.setMinutes(expiresAt.getMinutes() + 60);
+
+    return {
+      intentId,
+      destination: config.stellar.platformPublicKey,
+      amount,
+      asset: "native", // Default to XLM (Lumens)
+      memo: memoHash,
+      memoType: "hash",
+      expiresAt,
+    };
+  }
+}

--- a/apps/api/src/modules/payments/payments.controller.ts
+++ b/apps/api/src/modules/payments/payments.controller.ts
@@ -1,0 +1,30 @@
+import { Router, Request, Response } from "express";
+import { PaymentIntentService } from "./intent.service";
+
+const router = Router();
+
+/**
+ * POST /api/v1/payments/intent
+ * Body: { clinicId: string, amount: string }
+ */
+router.post("/intent", (req: Request, res: Response) => {
+  try {
+    const { clinicId, amount } = req.body;
+
+    if (!clinicId || !amount) {
+      return res.status(400).json({ error: "Missing clinicId or amount" });
+    }
+
+    const intent = PaymentIntentService.createIntent(clinicId, amount);
+
+    res.json({
+      status: "success",
+      data: intent,
+    });
+  } catch (error: any) {
+    console.error("Payment Intent Error:", error);
+    res.status(500).json({ error: error.message });
+  }
+});
+
+export const paymentRoutes = router;


### PR DESCRIPTION
### Feature: Implement Payment Intent Generator (#57)

This PR adds a payment intent generator to create on-chain payment instructions for clinics before payment is made.

**What’s included**

* Adds `createPaymentIntent(clinicId, amount)` in
  `apps/api/src/modules/payments/intent.service.ts`
* Generates a **unique memo** to track a specific payment attempt and link Web2 (Clinic ID) to Web3
* Applies an **expiration window** (e.g. 30 minutes) to each intent
* Returns a payment intent object containing:

  * `destinationAddress`
  * `memo`
  * `amount`
  * `asset`
  * `intentId`

**Acceptance**

* Destination address is sourced from configuration
* Memo string is unique per intent
* Pure logic only — no database writes

closes #57 