### PR TITLE
feat(auth): implement onboarding registration page with multi-step fo…

### DIFF
--- a/apps/web/app/(auth)/register/page.tsx
+++ b/apps/web/app/(auth)/register/page.tsx
@@ -1,0 +1,340 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { useAuth } from "@/providers/AuthProvider";
+
+const onboardingSchema = z.object({
+  clinicName: z
+    .string()
+    .trim()
+    .min(2, "Clinic name must be at least 2 characters."),
+  location: z
+    .string()
+    .trim()
+    .min(2, "Location is required."),
+  contactNumber: z
+    .string()
+    .trim()
+    .min(7, "Contact number is required."),
+  adminName: z
+    .string()
+    .trim()
+    .min(2, "Admin name must be at least 2 characters."),
+  adminEmail: z
+    .string()
+    .email("Please enter a valid email address."),
+  adminPassword: z
+    .string()
+    .min(8, "Password must be at least 8 characters long."),
+});
+
+type OnboardingForm = z.infer<typeof onboardingSchema>;
+
+type Toast = {
+  tone: "error" | "warning";
+  message: string;
+};
+
+const stepFields: Array<Array<keyof OnboardingForm>> = [
+  ["clinicName", "location", "contactNumber"],
+  ["adminName", "adminEmail", "adminPassword"],
+];
+
+const apiBaseUrl =
+  process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:4000/api/v1";
+
+export default function RegisterPage() {
+  const router = useRouter();
+  const { startSession } = useAuth();
+
+  const [step, setStep] = useState<0 | 1>(0);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [toast, setToast] = useState<Toast | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    trigger,
+    formState: { errors },
+  } = useForm<OnboardingForm>({
+    resolver: zodResolver(onboardingSchema),
+    shouldUnregister: false,
+    defaultValues: {
+      clinicName: "",
+      location: "",
+      contactNumber: "",
+      adminName: "",
+      adminEmail: "",
+      adminPassword: "",
+    },
+  });
+
+  const stepTitle = useMemo(
+    () =>
+      step === 0 ? "Clinic Profile" : "Admin Account Setup",
+    [step],
+  );
+
+  const onNextStep = async () => {
+    const isStepValid = await trigger(stepFields[step], { shouldFocus: true });
+    if (!isStepValid) {
+      return;
+    }
+
+    setStep(1);
+  };
+
+  const onBackStep = () => setStep(0);
+
+  const onSubmit = handleSubmit(async (values) => {
+    setToast(null);
+    setIsSubmitting(true);
+
+    try {
+      const response = await fetch(`${apiBaseUrl}/clinics/register`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          clinicName: values.clinicName,
+          adminEmail: values.adminEmail,
+          adminPassword: values.adminPassword,
+        }),
+      });
+
+      if (!response.ok) {
+        if (response.status === 409) {
+          setToast({
+            tone: "error",
+            message: "Registration failed. Admin email may already be in use.",
+          });
+          return;
+        }
+
+        if (response.status >= 500) {
+          setToast({
+            tone: "warning",
+            message: "Server unavailable. Please try again shortly.",
+          });
+          return;
+        }
+
+        setToast({
+          tone: "error",
+          message: "Unable to complete setup. Please review your inputs.",
+        });
+        return;
+      }
+
+      const payload = (await response.json()) as {
+        data?: { accessToken?: string; refreshToken?: string };
+      };
+
+      const accessToken = payload.data?.accessToken;
+      const refreshToken = payload.data?.refreshToken;
+      if (!accessToken || !refreshToken) {
+        setToast({
+          tone: "error",
+          message: "Invalid server response. Please retry.",
+        });
+        return;
+      }
+
+      startSession({ accessToken, refreshToken });
+      router.replace("/dashboard");
+    } catch {
+      setToast({
+        tone: "warning",
+        message: "Network error. Check your connection and try again.",
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  });
+
+  return (
+    <main className="min-h-screen bg-slate-50 px-4 py-10 sm:px-6 lg:px-8">
+      <div className="mx-auto w-full max-w-4xl rounded-2xl border border-slate-200 bg-white p-6 shadow-sm md:p-8">
+        <header className="mb-8 border-b border-slate-200 pb-6">
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+            LumenHealth Onboarding
+          </p>
+          <div className="mt-3 flex flex-col justify-between gap-4 md:flex-row md:items-end">
+            <div>
+              <h1 className="text-2xl font-semibold text-slate-900">{stepTitle}</h1>
+              <p className="mt-1 text-sm text-slate-600">Step {step + 1} of 2</p>
+            </div>
+            <div className="flex w-full max-w-xs gap-2">
+              <div
+                className={`h-2 flex-1 rounded-full ${step >= 0 ? "bg-teal-700" : "bg-slate-200"}`}
+              />
+              <div
+                className={`h-2 flex-1 rounded-full ${step >= 1 ? "bg-teal-700" : "bg-slate-200"}`}
+              />
+            </div>
+          </div>
+        </header>
+
+        <form className="space-y-8" onSubmit={onSubmit} noValidate>
+          {step === 0 ? (
+            <section className="grid gap-5 md:grid-cols-2">
+              <div className="space-y-2 md:col-span-2">
+                <label className="text-sm font-medium text-slate-800" htmlFor="clinicName">
+                  Clinic Name
+                </label>
+                <input
+                  id="clinicName"
+                  {...register("clinicName")}
+                  placeholder="e.g. Sunrise Community Clinic"
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2.5 text-sm text-slate-900 outline-none transition focus:border-teal-600 focus:ring-2 focus:ring-teal-100"
+                />
+                {errors.clinicName ? (
+                  <p className="text-xs font-medium text-red-600">{errors.clinicName.message}</p>
+                ) : null}
+              </div>
+
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-slate-800" htmlFor="location">
+                  Location
+                </label>
+                <input
+                  id="location"
+                  {...register("location")}
+                  placeholder="City, Region"
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2.5 text-sm text-slate-900 outline-none transition focus:border-teal-600 focus:ring-2 focus:ring-teal-100"
+                />
+                {errors.location ? (
+                  <p className="text-xs font-medium text-red-600">{errors.location.message}</p>
+                ) : null}
+              </div>
+
+              <div className="space-y-2">
+                <label
+                  className="text-sm font-medium text-slate-800"
+                  htmlFor="contactNumber"
+                >
+                  Contact Number
+                </label>
+                <input
+                  id="contactNumber"
+                  {...register("contactNumber")}
+                  placeholder="+1 555 000 1234"
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2.5 text-sm text-slate-900 outline-none transition focus:border-teal-600 focus:ring-2 focus:ring-teal-100"
+                />
+                {errors.contactNumber ? (
+                  <p className="text-xs font-medium text-red-600">
+                    {errors.contactNumber.message}
+                  </p>
+                ) : null}
+              </div>
+            </section>
+          ) : (
+            <section className="grid gap-5 md:grid-cols-2">
+              <div className="space-y-2 md:col-span-2">
+                <label className="text-sm font-medium text-slate-800" htmlFor="adminName">
+                  Admin Name
+                </label>
+                <input
+                  id="adminName"
+                  {...register("adminName")}
+                  placeholder="Full name"
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2.5 text-sm text-slate-900 outline-none transition focus:border-teal-600 focus:ring-2 focus:ring-teal-100"
+                />
+                {errors.adminName ? (
+                  <p className="text-xs font-medium text-red-600">{errors.adminName.message}</p>
+                ) : null}
+              </div>
+
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-slate-800" htmlFor="adminEmail">
+                  Admin Email
+                </label>
+                <input
+                  id="adminEmail"
+                  type="email"
+                  {...register("adminEmail")}
+                  placeholder="admin@clinic.org"
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2.5 text-sm text-slate-900 outline-none transition focus:border-teal-600 focus:ring-2 focus:ring-teal-100"
+                />
+                {errors.adminEmail ? (
+                  <p className="text-xs font-medium text-red-600">{errors.adminEmail.message}</p>
+                ) : null}
+              </div>
+
+              <div className="space-y-2">
+                <label
+                  className="text-sm font-medium text-slate-800"
+                  htmlFor="adminPassword"
+                >
+                  Password
+                </label>
+                <input
+                  id="adminPassword"
+                  type="password"
+                  {...register("adminPassword")}
+                  placeholder="Minimum 8 characters"
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2.5 text-sm text-slate-900 outline-none transition focus:border-teal-600 focus:ring-2 focus:ring-teal-100"
+                />
+                {errors.adminPassword ? (
+                  <p className="text-xs font-medium text-red-600">
+                    {errors.adminPassword.message}
+                  </p>
+                ) : null}
+              </div>
+            </section>
+          )}
+
+          {toast ? (
+            <div
+              className={`rounded-lg border px-4 py-3 text-sm ${
+                toast.tone === "error"
+                  ? "border-red-200 bg-red-50 text-red-900"
+                  : "border-amber-200 bg-amber-50 text-amber-900"
+              }`}
+              role="status"
+              aria-live="polite"
+            >
+              {toast.message}
+            </div>
+          ) : null}
+
+          <footer className="flex flex-wrap items-center justify-between gap-3 border-t border-slate-200 pt-6">
+            {step === 0 ? (
+              <div className="text-xs text-slate-500">You can review details before completing setup.</div>
+            ) : (
+              <button
+                type="button"
+                onClick={onBackStep}
+                className="rounded-lg border border-slate-300 px-4 py-2.5 text-sm font-medium text-slate-700 transition hover:bg-slate-100"
+                disabled={isSubmitting}
+              >
+                Back
+              </button>
+            )}
+
+            {step === 0 ? (
+              <button
+                type="button"
+                onClick={onNextStep}
+                className="rounded-lg bg-teal-700 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-teal-800"
+              >
+                Next
+              </button>
+            ) : (
+              <button
+                type="submit"
+                className="rounded-lg bg-teal-700 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-teal-800 disabled:cursor-not-allowed disabled:bg-slate-400"
+                disabled={isSubmitting}
+              >
+                {isSubmitting ? "Completing Setup..." : "Complete Setup"}
+              </button>
+            )}
+          </footer>
+        </form>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -1,18 +1,61 @@
 "use client";
 
-import { useState } from "react";
-import { useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { useAuth } from "@/providers/AuthProvider";
+import { z } from "zod";
+import { AuthError, useAuth } from "@/providers/AuthProvider";
+
+type Toast = {
+  id: string;
+  tone: "success" | "error" | "warning";
+  title: string;
+  message: string;
+};
+
+type AuthMode = "login" | "forgot";
+
+const loginSchema = z.object({
+  email: z.string().email("Please enter a valid email address."),
+  password: z
+    .string()
+    .min(8, "Password must be at least 8 characters long."),
+});
+
+const forgotSchema = z.object({
+  email: z.string().email("Please enter a valid email address."),
+});
+
+const toneClassMap: Record<Toast["tone"], string> = {
+  success: "border-emerald-200 bg-emerald-50 text-emerald-900",
+  error: "border-red-200 bg-red-50 text-red-900",
+  warning: "border-amber-200 bg-amber-50 text-amber-900",
+};
+
+const Spinner = () => (
+  <span
+    aria-hidden="true"
+    className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-white/50 border-t-white"
+  />
+);
 
 export default function LoginPage() {
   const router = useRouter();
   const { login, isAuthenticated } = useAuth();
 
+  const [mode, setMode] = useState<AuthMode>("login");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [formErrors, setFormErrors] = useState<Record<string, string>>({});
+  const [toasts, setToasts] = useState<Toast[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+
+  const subtitle = useMemo(() => {
+    if (mode === "forgot") {
+      return "Enter your work email and we will send a reset link.";
+    }
+
+    return "Sign in to continue to the clinic dashboard.";
+  }, [mode]);
 
   useEffect(() => {
     if (isAuthenticated) {
@@ -20,53 +63,271 @@ export default function LoginPage() {
     }
   }, [isAuthenticated, router]);
 
-  const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+  useEffect(() => {
+    if (toasts.length === 0) {
+      return;
+    }
+
+    const timeout = setTimeout(() => {
+      setToasts((previous) => previous.slice(1));
+    }, 3500);
+
+    return () => clearTimeout(timeout);
+  }, [toasts]);
+
+  const pushToast = (toast: Omit<Toast, "id">) => {
+    setToasts((previous) => [
+      ...previous,
+      {
+        ...toast,
+        id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      },
+    ]);
+  };
+
+  const resetErrors = () => setFormErrors({});
+
+  const onLoginSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    resetErrors();
+
+    const result = loginSchema.safeParse({ email, password });
+    if (!result.success) {
+      const issues: Record<string, string> = {};
+      for (const issue of result.error.issues) {
+        if (issue.path.length > 0) {
+          issues[String(issue.path[0])] = issue.message;
+        }
+      }
+
+      setFormErrors(issues);
+      return;
+    }
+
     setIsSubmitting(true);
-    setError(null);
 
     try {
-      await login({ email, password });
-      const redirectPath =
-        new URLSearchParams(window.location.search).get("redirect") ||
-        "/dashboard";
-      router.replace(redirectPath);
+      await login(result.data);
+      router.replace("/dashboard");
+    } catch (error) {
+      if (error instanceof AuthError) {
+        if (error.code === "INVALID_CREDENTIALS") {
+          pushToast({
+            tone: "error",
+            title: "Invalid Credentials",
+            message: "Email or password is incorrect.",
+          });
+          return;
+        }
+
+        if (error.code === "NETWORK") {
+          pushToast({
+            tone: "warning",
+            title: "Network Error",
+            message: "Connection problem. Please retry when online.",
+          });
+          return;
+        }
+
+        pushToast({
+          tone: "error",
+          title: "Sign In Failed",
+          message: error.message,
+        });
+        return;
+      }
+
+      pushToast({
+        tone: "error",
+        title: "Unexpected Error",
+        message: "Something went wrong. Please try again.",
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const onForgotSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    resetErrors();
+
+    const result = forgotSchema.safeParse({ email });
+    if (!result.success) {
+      const issues: Record<string, string> = {};
+      for (const issue of result.error.issues) {
+        if (issue.path.length > 0) {
+          issues[String(issue.path[0])] = issue.message;
+        }
+      }
+
+      setFormErrors(issues);
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const baseUrl =
+        process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:4000/api/v1";
+
+      const response = await fetch(`${baseUrl}/auth/forgot-password`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(result.data),
+      });
+
+      if (!response.ok) {
+        if (response.status === 404 || response.status === 501) {
+          pushToast({
+            tone: "warning",
+            title: "Reset Unavailable",
+            message: "Password reset will be enabled in the next backend update.",
+          });
+          return;
+        }
+
+        pushToast({
+          tone: "error",
+          title: "Request Failed",
+          message: "Unable to send reset link. Please try again.",
+        });
+        return;
+      }
+
+      pushToast({
+        tone: "success",
+        title: "Reset Link Sent",
+        message: "Check your email for password reset instructions.",
+      });
+      setMode("login");
     } catch {
-      setError("Invalid credentials or network error");
+      pushToast({
+        tone: "warning",
+        title: "Network Error",
+        message: "Connection problem. Please retry when online.",
+      });
     } finally {
       setIsSubmitting(false);
     }
   };
 
   return (
-    <main className="mx-auto mt-24 w-full max-w-md px-6">
-      <h1 className="text-2xl font-semibold">Login</h1>
-      <form className="mt-6 space-y-4" onSubmit={onSubmit}>
-        <input
-          className="w-full rounded border p-2"
-          type="email"
-          value={email}
-          onChange={(event) => setEmail(event.target.value)}
-          placeholder="Email"
-          required
-        />
-        <input
-          className="w-full rounded border p-2"
-          type="password"
-          value={password}
-          onChange={(event) => setPassword(event.target.value)}
-          placeholder="Password"
-          required
-        />
-        {error ? <p className="text-sm text-red-600">{error}</p> : null}
-        <button
-          className="w-full rounded bg-black px-4 py-2 text-white disabled:opacity-50"
-          type="submit"
-          disabled={isSubmitting}
-        >
-          {isSubmitting ? "Signing in..." : "Sign in"}
-        </button>
-      </form>
+    <main className="min-h-screen bg-slate-50 px-4 py-16 sm:px-6 lg:px-8">
+      <div className="mx-auto w-full max-w-md">
+        <section className="rounded-2xl border border-slate-200 bg-white p-8 shadow-sm">
+          <header className="mb-8">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+              LumenHealth
+            </p>
+            <h1 className="mt-2 text-2xl font-semibold text-slate-900">
+              {mode === "login" ? "Sign In" : "Reset Password"}
+            </h1>
+            <p className="mt-2 text-sm text-slate-600">{subtitle}</p>
+          </header>
+
+          <form
+            className="space-y-5"
+            onSubmit={mode === "login" ? onLoginSubmit : onForgotSubmit}
+          >
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-slate-800" htmlFor="email">
+                Email
+              </label>
+              <input
+                id="email"
+                className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2.5 text-sm text-slate-900 outline-none transition focus:border-teal-600 focus:ring-2 focus:ring-teal-100"
+                type="email"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                placeholder="name@clinic.org"
+                autoComplete="email"
+              />
+              {formErrors.email ? (
+                <p className="text-xs font-medium text-red-600">{formErrors.email}</p>
+              ) : null}
+            </div>
+
+            {mode === "login" ? (
+              <div className="space-y-2">
+                <label
+                  className="text-sm font-medium text-slate-800"
+                  htmlFor="password"
+                >
+                  Password
+                </label>
+                <input
+                  id="password"
+                  className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2.5 text-sm text-slate-900 outline-none transition focus:border-teal-600 focus:ring-2 focus:ring-teal-100"
+                  type="password"
+                  value={password}
+                  onChange={(event) => setPassword(event.target.value)}
+                  placeholder="Enter your password"
+                  autoComplete="current-password"
+                />
+                {formErrors.password ? (
+                  <p className="text-xs font-medium text-red-600">{formErrors.password}</p>
+                ) : null}
+              </div>
+            ) : null}
+
+            <button
+              className="flex w-full items-center justify-center gap-2 rounded-lg bg-teal-700 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-teal-800 disabled:cursor-not-allowed disabled:bg-slate-400"
+              type="submit"
+              disabled={isSubmitting}
+            >
+              {isSubmitting ? <Spinner /> : null}
+              {isSubmitting
+                ? mode === "login"
+                  ? "Signing In..."
+                  : "Sending Link..."
+                : mode === "login"
+                  ? "Sign In"
+                  : "Send Reset Link"}
+            </button>
+          </form>
+
+          <div className="mt-6 flex items-center justify-between text-sm">
+            {mode === "login" ? (
+              <button
+                type="button"
+                className="font-medium text-teal-700 hover:text-teal-800"
+                onClick={() => {
+                  setMode("forgot");
+                  resetErrors();
+                }}
+              >
+                Forgot Password?
+              </button>
+            ) : (
+              <button
+                type="button"
+                className="font-medium text-teal-700 hover:text-teal-800"
+                onClick={() => {
+                  setMode("login");
+                  resetErrors();
+                }}
+              >
+                Back to Sign In
+              </button>
+            )}
+            <span className="text-xs text-slate-500">Secure clinic access</span>
+          </div>
+        </section>
+      </div>
+
+      <div className="pointer-events-none fixed right-4 top-4 z-50 flex w-full max-w-sm flex-col gap-2">
+        {toasts.map((toast) => (
+          <div
+            key={toast.id}
+            className={`pointer-events-auto rounded-lg border px-4 py-3 shadow-sm ${toneClassMap[toast.tone]}`}
+            role="status"
+            aria-live="polite"
+          >
+            <p className="text-sm font-semibold">{toast.title}</p>
+            <p className="mt-0.5 text-xs">{toast.message}</p>
+          </div>
+        ))}
+      </div>
     </main>
   );
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,10 +9,13 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.2",
     "@lumen/config": "^1.0.0",
     "next": "16.1.4",
     "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "react-dom": "19.2.3",
+    "react-hook-form": "^7.71.2",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,10 +58,13 @@
       "name": "@lumen/web",
       "version": "0.1.0",
       "dependencies": {
+        "@hookform/resolvers": "^5.2.2",
         "@lumen/config": "^1.0.0",
         "next": "16.1.4",
         "react": "19.2.3",
-        "react-dom": "19.2.3"
+        "react-dom": "19.2.3",
+        "react-hook-form": "^7.71.2",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -987,6 +990,18 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
+      "integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1839,6 +1854,12 @@
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@stellar/js-xdr": {
@@ -7189,6 +7210,22 @@
       },
       "peerDependencies": {
         "react": "^19.2.3"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.71.2",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.2.tgz",
+      "integrity": "sha512-1CHvcDYzuRUNOflt4MOq3ZM46AronNJtQ1S7tnX6YN4y72qhgiUItpacZUAQ0TyWYci3yz1X+rXaSxiuEm86PA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {


### PR DESCRIPTION
added a multi-step registration flow at `apps/web/src/app/(auth)/register/page.tsx` using React Hook Form and Zod for cross-step validation, preserving form state while navigating between Clinic Details and Admin Setup steps and submitting a consolidated payload to `POST /clinics/register`, with successful registration redirecting directly to the Clinic Dashboard. It also introduces a responsive login page at `apps/web/src/app/(auth)/login/page.tsx` with Zod validation, AuthProvider integration, loading state handling, disabled submit during requests, spinner feedback, and clear toast notifications for network and credential errors, redirecting authenticated users to `/dashboard` via the Next.js router.

closes #71 
closes #75
