### PR TITLE
feat: add subscription lock UI components and state management

### DIFF
--- a/contrib/clinic-ops-sandbox/ui-subscription-lock/App.jsx
+++ b/contrib/clinic-ops-sandbox/ui-subscription-lock/App.jsx
@@ -1,0 +1,108 @@
+import { useMemo, useState } from "react";
+import { SubscriptionLayout } from "./SubscriptionLockUI";
+
+const modes = {
+  active: "2026-03-20T12:00:00.000Z",
+  expiring: "2026-03-02T12:00:00.000Z",
+  expired: "2026-02-20T12:00:00.000Z",
+};
+
+const NOW = "2026-02-25T12:00:00.000Z";
+
+export default function App() {
+  const [mode, setMode] = useState("active");
+
+  const expiryIso = useMemo(() => modes[mode], [mode]);
+
+  return (
+    <main
+      style={{
+        minHeight: "100vh",
+        background: "#f8fafc",
+        fontFamily: "Inter, Roboto, sans-serif",
+        color: "#0f172a",
+      }}
+    >
+      <div style={{ padding: 16 }}>
+        <h1 style={{ margin: 0, fontSize: 22 }}>Subscription Lock UI Demo</h1>
+        <p style={{ marginTop: 6, color: "#475569", fontSize: 13 }}>
+          Toggle states to test active, expiring, and expired behavior.
+        </p>
+
+        <div style={{ display: "flex", gap: 8, marginTop: 12, marginBottom: 14 }}>
+          {Object.keys(modes).map((key) => (
+            <button
+              key={key}
+              type="button"
+              onClick={() => setMode(key)}
+              style={{
+                padding: "7px 12px",
+                borderRadius: 8,
+                border: "1px solid #cbd5e1",
+                background: mode === key ? "#0f766e" : "#ffffff",
+                color: mode === key ? "#ffffff" : "#0f172a",
+                fontWeight: 600,
+                cursor: "pointer",
+              }}
+            >
+              {key}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <SubscriptionLayout
+        expiryIso={expiryIso}
+        nowIso={NOW}
+        onPayNow={() => window.alert("Redirect to Stellar checkout")}
+      >
+        <section style={{ padding: 16 }}>
+          <div
+            style={{
+              border: "1px solid #e2e8f0",
+              borderRadius: 12,
+              background: "#ffffff",
+              padding: 16,
+            }}
+          >
+            <h2 style={{ margin: 0, fontSize: 18 }}>Clinic Dashboard</h2>
+            <p style={{ margin: "8px 0 14px", color: "#475569", fontSize: 13 }}>
+              Primary actions should be disabled when subscription is expired.
+            </p>
+
+            <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+              <button
+                type="button"
+                style={{
+                  border: "none",
+                  borderRadius: 8,
+                  background: "#0f766e",
+                  color: "#ffffff",
+                  padding: "8px 12px",
+                  fontWeight: 600,
+                  cursor: "pointer",
+                }}
+              >
+                New Patient
+              </button>
+              <button
+                type="button"
+                style={{
+                  border: "none",
+                  borderRadius: 8,
+                  background: "#0369a1",
+                  color: "#ffffff",
+                  padding: "8px 12px",
+                  fontWeight: 600,
+                  cursor: "pointer",
+                }}
+              >
+                Edit Profile
+              </button>
+            </div>
+          </div>
+        </section>
+      </SubscriptionLayout>
+    </main>
+  );
+}

--- a/contrib/clinic-ops-sandbox/ui-subscription-lock/README.md
+++ b/contrib/clinic-ops-sandbox/ui-subscription-lock/README.md
@@ -1,0 +1,24 @@
+# UI Subscription Lock (Standalone)
+
+Standalone global subscription-lock UX components.
+
+## Includes
+
+- Sticky warning banner for expiring state (< 7 days).
+- Sticky red banner for expired state with `Pay Now` button.
+- Action-lock wrapper that visually and functionally disables primary actions when expired.
+- Utility function for days-remaining calculation.
+
+## Files
+
+- `subscription-state.js` computes `active | expiring | expired`.
+- `SubscriptionLockUI.jsx` exports `SubscriptionLayout` and `ActionLock`.
+- `App.jsx` demo with state toggles.
+
+## Usage
+
+```jsx
+<SubscriptionLayout expiryIso={expiryIso} nowIso={nowIso} onPayNow={handlePayNow}>
+  <DashboardActions />
+</SubscriptionLayout>
+```

--- a/contrib/clinic-ops-sandbox/ui-subscription-lock/SubscriptionLockUI.jsx
+++ b/contrib/clinic-ops-sandbox/ui-subscription-lock/SubscriptionLockUI.jsx
@@ -1,0 +1,103 @@
+import { getSubscriptionState } from "./subscription-state";
+
+function Banner({ state, onPayNow }) {
+  if (state.status === "active") {
+    return null;
+  }
+
+  const isExpired = state.status === "expired";
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      style={{
+        position: "sticky",
+        top: 0,
+        zIndex: 40,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: 12,
+        padding: "10px 14px",
+        borderBottom: `1px solid ${isExpired ? "#fecaca" : "#fde68a"}`,
+        background: isExpired ? "#fef2f2" : "#fffbeb",
+        color: isExpired ? "#991b1b" : "#92400e",
+      }}
+    >
+      <span style={{ fontSize: 13, fontWeight: 600 }}>
+        {isExpired
+          ? "Subscription Expired. Write access is disabled. Please renew via Stellar to restore full functionality."
+          : `Subscription expiring soon (${state.daysRemaining} day${
+              state.daysRemaining === 1 ? "" : "s"
+            } remaining).`}
+      </span>
+
+      <button
+        type="button"
+        onClick={onPayNow}
+        style={{
+          border: "none",
+          borderRadius: 8,
+          padding: "7px 12px",
+          fontSize: 12,
+          fontWeight: 700,
+          cursor: "pointer",
+          background: isExpired ? "#dc2626" : "#d97706",
+          color: "#ffffff",
+        }}
+      >
+        Pay Now
+      </button>
+    </div>
+  );
+}
+
+export function ActionLock({ state, children }) {
+  if (!state.writeLocked) {
+    return <>{children}</>;
+  }
+
+  return (
+    <div style={{ position: "relative" }}>
+      <div style={{ opacity: 0.45, pointerEvents: "none", filter: "grayscale(0.35)" }}>
+        {children}
+      </div>
+      <div
+        style={{
+          position: "absolute",
+          inset: 0,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          pointerEvents: "none",
+        }}
+      >
+        <span
+          style={{
+            background: "#fee2e2",
+            color: "#991b1b",
+            border: "1px solid #fecaca",
+            borderRadius: 8,
+            padding: "6px 10px",
+            fontSize: 12,
+            fontWeight: 600,
+          }}
+        >
+          Write actions disabled until subscription renewal
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export function SubscriptionLayout({ expiryIso, nowIso, onPayNow, children }) {
+  const state = getSubscriptionState(expiryIso, nowIso);
+
+  return (
+    <div>
+      <Banner state={state} onPayNow={onPayNow} />
+      <ActionLock state={state}>{children}</ActionLock>
+    </div>
+  );
+}

--- a/contrib/clinic-ops-sandbox/ui-subscription-lock/package.json
+++ b/contrib/clinic-ops-sandbox/ui-subscription-lock/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "ui-subscription-lock",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Standalone subscription lock banner and action guard",
+  "scripts": {
+    "lint": "echo 'No build tooling configured. Use in a React sandbox.'"
+  },
+  "peerDependencies": {
+    "react": ">=18"
+  }
+}

--- a/contrib/clinic-ops-sandbox/ui-subscription-lock/subscription-state.js
+++ b/contrib/clinic-ops-sandbox/ui-subscription-lock/subscription-state.js
@@ -1,0 +1,29 @@
+export function getSubscriptionState(expiryIso, nowIso = new Date().toISOString()) {
+  const expiry = new Date(expiryIso);
+  const now = new Date(nowIso);
+
+  const msRemaining = expiry.getTime() - now.getTime();
+  const daysRemaining = Math.ceil(msRemaining / (1000 * 60 * 60 * 24));
+
+  if (msRemaining < 0) {
+    return {
+      status: "expired",
+      daysRemaining: 0,
+      writeLocked: true,
+    };
+  }
+
+  if (daysRemaining < 7) {
+    return {
+      status: "expiring",
+      daysRemaining,
+      writeLocked: false,
+    };
+  }
+
+  return {
+    status: "active",
+    daysRemaining,
+    writeLocked: false,
+  };
+}


### PR DESCRIPTION
Adds a UI simulation of the global write-access lock behavior triggered by subscription expiry. Located in `contrib/clinic-ops-sandbox/ui-subscription-lock`, this sandbox demonstrates how the interface should respond across three subscription states: active, expiring, and expired.

**What's changed**

Built a sticky top banner that renders when the subscription is in an expired state, surfacing a warning message and a CTA to prompt renewal. The banner is intentionally persistent (sticky) to ensure it remains visible during any scrolling interaction.

Added a wrapper component (`LockedActionWrapper` or similar) that intercepts child action buttons and disables them when write access is blocked. This keeps lock enforcement centralized rather than scattered across individual button implementations.

Implemented a warning state that surfaces automatically when the subscription is within 7 days of expiry, giving users a heads-up before hard lockout kicks in. Days-remaining is derived from a comparison against the current date, validated against the sample dates included in the demo.

The demo page includes three toggle modes (active / expiring / expired) so reviewers can step through each state without needing a live subscription.

**Acceptance criteria met**

- Expired mode visually disables primary actions via the wrapper component
- Days-remaining calculation is correct across all provided sample dates
- Demo includes active, expiring, and expired toggles for manual review

closes #103 