### PR TITLE
Management dashboard

### DIFF
--- a/apps/web/app/dashboard/settings/staff/page.tsx
+++ b/apps/web/app/dashboard/settings/staff/page.tsx
@@ -173,6 +173,21 @@ export default function StaffManagementPage() {
     }
   }, [page, pageCount]);
 
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") {
+        return;
+      }
+
+      setActionMenuUserId(null);
+      setDeactivateTarget(null);
+      setIsCreateOpen(false);
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+
   const onCreateStaff = handleSubmit(async (values) => {
     setIsCreateSubmitting(true);
     setToast(null);


### PR DESCRIPTION
Clinic Admins now have a proper interface to manage their roster — view staff, onboard new members, and revoke access, all from one place. Lives in `apps/web/src/app/dashboard/settings/staff/page.tsx`.

**What's changing:**

- **Staff table** — displays name, role, and active status with pagination (client-side for now, switchable to server-side)
- **Create Staff modal** — overlay form with a Role dropdown; on success, the new member appears in the table immediately via React Query cache invalidation (no full page reload)
- **Deactivate action** — triggers a confirmation dialog before firing the `PATCH /users/:id/status` call, preventing accidental revocations

closes #125 