### PR TITLE
add platform foundation guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,29 @@ lumen-health/
 
 ```
 
+## Workspace Boundaries
+
+LumenHealth keeps runtime responsibilities explicit so contributors can work in parallel safely:
+
+- `apps/api`: backend domain modules and REST interfaces only
+- `apps/web`: Next.js operator experience only
+- `apps/stellar-service`: Stellar network operations and diagnostics only
+- `packages/config`: shared runtime configuration, feature flags, and platform guardrails
+- `packages/types`: shared schemas and cross-app TypeScript contracts
+
+Allowed shared imports are intentionally narrow:
+
+- app workspaces may import `@lumen/config` and `@lumen/types`
+- shared packages must not import app workspaces
+- cross-workspace root-relative imports are rejected by `npm run check:boundaries`
+
+Use the boundary checker before merging architecture-sensitive work:
+
+```bash
+npm run check:boundaries
+npm run check:boundaries:fixtures
+```
+
 ## Current MVP Surface
 
 The repository already contains:
@@ -186,6 +209,28 @@ To start **Frontend**, **Backend**, and **Services** simultaneously:
 npm run dev
 
 ```
+
+### Bootstrap Checks
+
+Before first run, validate local prerequisites and optional integrations:
+
+```bash
+npm run setup
+```
+
+To run the same bootstrap flow and seed the demo clinic in one pass:
+
+```bash
+npm run setup:seed-demo
+```
+
+Bootstrap validates:
+
+- Node.js and npm availability
+- root `.env` presence
+- required API secrets
+- optional Gemini and Stellar secrets
+- basic MongoDB host reachability when the URI is directly parseable
 
 * **Frontend:** [http://localhost:3000](https://www.google.com/search?q=http://localhost:3000)
 * **Backend:** [http://localhost:4000](https://www.google.com/search?q=http://localhost:4000)

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,6 +6,7 @@
     "dev": "tsx watch src/app.ts",
     "build": "tsc",
     "start": "node dist/app.js",
+    "seed:demo": "node scripts/seed-demo.cjs",
     "test": "npm run test:check && vitest run",
     "test:check": "node scripts/ensure-test-tooling.cjs"
   },

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import cors from 'cors';
-import { config } from '@lumen/config';
+import { config, getConfigDiagnostics } from '@lumen/config';
 import { connectDB } from './config/db';
 import { startPaymentVerificationWorker } from './modules/payments/worker';
 import { patientRoutes } from './modules/patients/patients.controller';
@@ -33,9 +33,13 @@ app.use('/api/v1/auth', authRoutes);
 app.use('/api/v1/clinics', clinicOnboardingRoutes);
 app.use('/api/v1/clinics', clinicSettingsRoutes);
 app.use('/api/v1/users', userRoutes);
-app.use('/api/v1/payments', paymentRoutes);
-app.use('/api/v1/ai', aiRoutes);
-app.use('/api/v1/ai', aiDraftRoutes);
+if (config.featureFlags.stellarBilling) {
+  app.use('/api/v1/payments', paymentRoutes);
+}
+if (config.featureFlags.aiSummaries) {
+  app.use('/api/v1/ai', aiRoutes);
+  app.use('/api/v1/ai', aiDraftRoutes);
+}
 app.use('/api/v1/queue', queueRoutes);
 app.use('/api/v1', diagnosisRoutes);
 app.use('/api/v1/patients', patientRoutes);
@@ -46,13 +50,27 @@ app.use('/api/v1/notes', notesRoutes);
 app.use('/api/v1/audit-logs', auditRoutes);
 
 app.get('/health', (_req, res) => {
-  res.json({ status: 'ok', timestamp: new Date() });
+  const diagnostics = getConfigDiagnostics();
+  res.json({
+    status: 'ok',
+    timestamp: new Date(),
+    featureFlags: config.featureFlags,
+    diagnostics: {
+      present: diagnostics.environment.filter((item) => item.status === 'present').length,
+      missing: diagnostics.environment.filter((item) => item.status === 'missing').length,
+      defaulted: diagnostics.environment.filter((item) => item.status === 'defaulted').length,
+    },
+  });
 });
 
 const start = async () => {
   await connectDB();
-  startPaymentVerificationWorker();
-  startCdsWorker();
+  if (config.featureFlags.stellarBilling) {
+    startPaymentVerificationWorker();
+  }
+  if (config.featureFlags.aiSummaries) {
+    startCdsWorker();
+  }
 
   app.listen(config.port, () => {
     console.log(`🚀 API running on http://localhost:${config.port}`);

--- a/apps/api/src/modules/ai/stream.controller.ts
+++ b/apps/api/src/modules/ai/stream.controller.ts
@@ -4,6 +4,7 @@ import { validateRequest } from "../../middlewares/validate.middleware";
 import { splitTextForSse, toSsePayload } from "./stream.utils";
 import { StreamSummaryQueryDto, streamSummaryQuerySchema } from "./stream.validation";
 import { ClinicalAlertModel } from "./models/clinical-alert.model";
+import { config } from "@lumen/config";
 import {
   AlertIdParamsDto,
   EncounterAlertsParamsDto,
@@ -41,7 +42,7 @@ const loadGeminiSdk = async () => {
 };
 
 const streamFromGemini = async (res: Response, encounterId: string) => {
-  const apiKey = process.env.GEMINI_API_KEY;
+  const apiKey = config.gemini.apiKey;
   if (!apiKey) {
     throw new Error("GEMINI_API_KEY is not configured");
   }
@@ -49,7 +50,7 @@ const streamFromGemini = async (res: Response, encounterId: string) => {
   const sdk = await loadGeminiSdk();
   const client = new sdk.GoogleGenerativeAI(apiKey);
   const model = client.getGenerativeModel({
-    model: process.env.GEMINI_MODEL || "gemini-1.5-flash",
+    model: config.gemini.model,
   });
 
   const streamMethod = model.streamGenerateContent ?? model.generateContentStream;

--- a/apps/web/app/(auth)/register/page.tsx
+++ b/apps/web/app/(auth)/register/page.tsx
@@ -6,6 +6,7 @@ import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { useAuth } from "@/providers/AuthProvider";
+import { getApiBaseUrl } from "@/lib/runtime-config";
 
 const onboardingSchema = z.object({
   clinicName: z
@@ -43,9 +44,6 @@ const stepFields: Array<Array<keyof OnboardingForm>> = [
   ["clinicName", "location", "contactNumber"],
   ["adminName", "adminEmail", "adminPassword"],
 ];
-
-const apiBaseUrl =
-  process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:4000/api/v1";
 
 export default function RegisterPage() {
   const router = useRouter();
@@ -95,7 +93,7 @@ export default function RegisterPage() {
     setIsSubmitting(true);
 
     try {
-      const response = await fetch(`${apiBaseUrl}/clinics/register`, {
+      const response = await fetch(`${getApiBaseUrl()}/clinics/register`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/apps/web/app/dashboard/billing/page.tsx
+++ b/apps/web/app/dashboard/billing/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { apiFetch } from "@/lib/api-client";
+import { isFeatureEnabled } from "@/lib/runtime-config";
 import { useAuth } from "@/providers/AuthProvider";
 import { useSubscription } from "@/providers/SubscriptionProvider";
 
@@ -36,6 +37,7 @@ const getStellarUri = (intent: PaymentIntent) =>
   )}&memo=${encodeURIComponent(intent.memo)}&memo_type=${encodeURIComponent(intent.memoType)}`;
 
 export default function BillingPage() {
+  const billingEnabled = isFeatureEnabled("stellarBilling");
   const { user } = useAuth();
   const { expiryDate, daysRemaining, isWriteLocked, refresh } = useSubscription();
 
@@ -159,6 +161,14 @@ export default function BillingPage() {
         <h1 className="text-xl font-semibold text-slate-900 md:text-2xl">Billing</h1>
       </header>
 
+      {!billingEnabled ? (
+        <section className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+          <h2 className="text-lg font-semibold text-slate-900">Billing Unavailable</h2>
+          <p className="mt-2 text-sm text-slate-600">
+            Stellar billing is currently disabled by runtime configuration.
+          </p>
+        </section>
+      ) : (
       <section className="grid gap-4 lg:grid-cols-[1fr_1.3fr]">
         <article className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
           <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-600">
@@ -325,6 +335,7 @@ export default function BillingPage() {
           ) : null}
         </article>
       </section>
+      )}
     </main>
   );
 }

--- a/apps/web/app/dashboard/queue/page.tsx
+++ b/apps/web/app/dashboard/queue/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { apiFetch } from "@/lib/api-client";
+import { getApiBaseUrl } from "@/lib/runtime-config";
 import { useAuth } from "@/providers/AuthProvider";
 
 type QueueStatus = "WAITING" | "TRIAGE" | "CONSULTATION";
@@ -15,8 +16,6 @@ type QueueItem = {
   openedAt: string;
   waitMinutes: number;
 };
-
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:4000/api/v1";
 
 const COLUMNS: Array<{ key: QueueStatus; label: string }> = [
   { key: "WAITING", label: "Waiting Room" },
@@ -97,7 +96,7 @@ export default function QueuePage() {
     }
 
     const stream = new EventSource(
-      `${API_BASE}/queue/stream?token=${encodeURIComponent(tokens.accessToken)}`,
+      `${getApiBaseUrl()}/queue/stream?token=${encodeURIComponent(tokens.accessToken)}`,
     );
 
     const onUpdate = (event: MessageEvent) => {

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { getPublicRuntimeConfig } from "@lumen/config";
 import { AuthProvider } from "@/providers/AuthProvider";
 import "./globals.css";
 
@@ -12,9 +13,16 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const runtimeConfig = JSON.stringify(getPublicRuntimeConfig());
+
   return (
     <html lang="en">
       <body className="antialiased">
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `window.__LUMEN_RUNTIME_CONFIG__ = ${runtimeConfig};`,
+          }}
+        />
         <AuthProvider>{children}</AuthProvider>
       </body>
     </html>

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { z } from "zod";
 import { AuthError, useAuth } from "@/providers/AuthProvider";
+import { getApiBaseUrl } from "@/lib/runtime-config";
 
 type Toast = {
   id: string;
@@ -167,10 +168,7 @@ export default function LoginPage() {
     setIsSubmitting(true);
 
     try {
-      const baseUrl =
-        process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:4000/api/v1";
-
-      const response = await fetch(`${baseUrl}/auth/forgot-password`, {
+      const response = await fetch(`${getApiBaseUrl()}/auth/forgot-password`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(result.data),

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,7 +1,7 @@
 import { config } from '@lumen/config';
 
 export default async function Home() {
-  const apiUrl = `http://localhost:${config.port}/health`;
+  const apiUrl = `${config.public.apiBaseUrl.replace(/\/api\/v1$/, '')}/health`;
 
   // DEBUG LOG: Check this in your VS Code terminal when you refresh
   console.log('🔍 Attempting to fetch from:', apiUrl);

--- a/apps/web/components/ai/Summarizer.tsx
+++ b/apps/web/components/ai/Summarizer.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { apiFetch } from "@/lib/api-client";
+import { isFeatureEnabled } from "@/lib/runtime-config";
 
 type Props = {
   encounterId: string;
@@ -41,6 +42,7 @@ const parseSseBlock = (block: string): { event: string; payload: unknown } | nul
 };
 
 export const Summarizer = ({ encounterId }: Props) => {
+  const aiEnabled = isFeatureEnabled("aiSummaries");
   const [content, setContent] = useState("");
   const [draftId, setDraftId] = useState<string | null>(null);
   const [isGenerating, setIsGenerating] = useState(false);
@@ -50,11 +52,21 @@ export const Summarizer = ({ encounterId }: Props) => {
   const [mode, setMode] = useState<"idle" | "draft">("idle");
 
   const canApprove = useMemo(
-    () => !isGenerating && !isSaving && mode === "draft" && content.trim().length > 0 && !!draftId,
-    [content, draftId, isGenerating, isSaving, mode],
+    () =>
+      aiEnabled &&
+      !isGenerating &&
+      !isSaving &&
+      mode === "draft" &&
+      content.trim().length > 0 &&
+      !!draftId,
+    [aiEnabled, content, draftId, isGenerating, isSaving, mode],
   );
 
   useEffect(() => {
+    if (!aiEnabled) {
+      return;
+    }
+
     const loadDraft = async () => {
       try {
         const response = await apiFetch(`/ai/drafts?encounterId=${encodeURIComponent(encounterId)}`);
@@ -79,7 +91,18 @@ export const Summarizer = ({ encounterId }: Props) => {
     };
 
     void loadDraft();
-  }, [encounterId]);
+  }, [aiEnabled, encounterId]);
+
+  if (!aiEnabled) {
+    return (
+      <section className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="text-lg font-semibold text-slate-900">AI Summary</h2>
+        <p className="mt-2 text-sm text-slate-600">
+          AI summarization is currently disabled by runtime configuration.
+        </p>
+      </section>
+    );
+  }
 
   const startGeneration = async (useDummyStream = false) => {
     if (isGenerating || isSaving) {

--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -1,4 +1,5 @@
 import { AuthTokens } from "./auth-session";
+import { getApiBaseUrl } from "@/lib/runtime-config";
 
 type AuthBindings = {
   getTokens: () => AuthTokens | null;
@@ -7,9 +8,6 @@ type AuthBindings = {
 };
 
 let bindings: AuthBindings | null = null;
-
-const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:4000/api/v1";
 
 export const configureApiClient = (authBindings: AuthBindings) => {
   bindings = authBindings;
@@ -20,7 +18,7 @@ const buildUrl = (path: string) => {
     return path;
   }
 
-  return `${API_BASE_URL}${path.startsWith("/") ? path : `/${path}`}`;
+  return `${getApiBaseUrl()}${path.startsWith("/") ? path : `/${path}`}`;
 };
 
 const withAuthHeader = (init: RequestInit, accessToken: string): RequestInit => {

--- a/apps/web/lib/runtime-config.ts
+++ b/apps/web/lib/runtime-config.ts
@@ -1,0 +1,39 @@
+type RuntimeFeatureFlags = {
+  aiSummaries: boolean;
+  stellarBilling: boolean;
+  offlineMode: boolean;
+};
+
+type RuntimeConfig = {
+  apiBaseUrl: string;
+  featureFlags: RuntimeFeatureFlags;
+};
+
+declare global {
+  interface Window {
+    __LUMEN_RUNTIME_CONFIG__?: RuntimeConfig;
+  }
+}
+
+const fallbackConfig: RuntimeConfig = {
+  apiBaseUrl: process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:4000/api/v1',
+  featureFlags: {
+    aiSummaries: true,
+    stellarBilling: true,
+    offlineMode: false,
+  },
+};
+
+export const getRuntimeConfig = (): RuntimeConfig => {
+  if (typeof window === 'undefined') {
+    return fallbackConfig;
+  }
+
+  return window.__LUMEN_RUNTIME_CONFIG__ ?? fallbackConfig;
+};
+
+export const getApiBaseUrl = () => getRuntimeConfig().apiBaseUrl;
+
+export const getFeatureFlags = () => getRuntimeConfig().featureFlags;
+
+export const isFeatureEnabled = (key: keyof RuntimeFeatureFlags) => getFeatureFlags()[key];

--- a/apps/web/providers/AuthProvider.tsx
+++ b/apps/web/providers/AuthProvider.tsx
@@ -18,6 +18,7 @@ import {
   saveTokens,
 } from "@/lib/auth-session";
 import { configureApiClient } from "@/lib/api-client";
+import { getApiBaseUrl } from "@/lib/runtime-config";
 
 type AuthState = {
   user: AuthUser | null;
@@ -55,9 +56,6 @@ type AuthContextValue = AuthState & {
 };
 
 const AuthContext = createContext<AuthContextValue | null>(null);
-
-const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:4000/api/v1";
 
 const parseTokensFromResponse = (raw: unknown): AuthTokens | null => {
   if (!raw || typeof raw !== "object") {
@@ -115,7 +113,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       return null;
     }
 
-    const response = await fetch(`${API_BASE_URL}/auth/refresh`, {
+    const response = await fetch(`${getApiBaseUrl()}/auth/refresh`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ refreshToken }),
@@ -149,7 +147,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     async (credentials: LoginCredentials) => {
       let response: Response;
       try {
-        response = await fetch(`${API_BASE_URL}/auth/login`, {
+        response = await fetch(`${getApiBaseUrl()}/auth/login`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(credentials),

--- a/package.json
+++ b/package.json
@@ -7,6 +7,11 @@
     "packages/*"
   ],
   "scripts": {
+    "setup": "node packages/config/bootstrap.cjs",
+    "setup:seed-demo": "node packages/config/bootstrap.cjs --seed-demo",
+    "check:env": "node packages/config/bootstrap.cjs",
+    "check:boundaries": "npm run check:boundaries -w packages/config",
+    "check:boundaries:fixtures": "npm run check:boundaries:fixtures -w packages/config",
     "dev": "turbo run dev",
     "build": "turbo run build",
     "start": "turbo run start",

--- a/packages/config/bootstrap.cjs
+++ b/packages/config/bootstrap.cjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+const fs = require('node:fs');
+const path = require('node:path');
+const net = require('node:net');
+const { spawnSync } = require('node:child_process');
+
+const root = path.resolve(__dirname, '..', '..');
+const envPath = path.join(root, '.env');
+const args = new Set(process.argv.slice(2));
+
+if (fs.existsSync(envPath)) {
+  const envContent = fs.readFileSync(envPath, 'utf8');
+  for (const line of envContent.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) {
+      continue;
+    }
+
+    const separatorIndex = trimmed.indexOf('=');
+    if (separatorIndex === -1) {
+      continue;
+    }
+
+    const key = trimmed.slice(0, separatorIndex).trim();
+    const value = trimmed.slice(separatorIndex + 1).trim().replace(/^['"]|['"]$/g, '');
+    if (key && !process.env[key]) {
+      process.env[key] = value;
+    }
+  }
+}
+
+const requiredEnvVars = [
+  'MONGO_URI',
+  'JWT_ACCESS_TOKEN_SECRET',
+  'JWT_REFRESH_TOKEN_SECRET',
+];
+
+const optionalFeatureEnvVars = [
+  'GEMINI_API_KEY',
+  'STELLAR_PLATFORM_PUBLIC_KEY',
+  'STELLAR_SECRET_KEY',
+];
+
+function getNodeVersion() {
+  const [major] = process.versions.node.split('.').map((value) => Number(value));
+  return major;
+}
+
+function run(command, commandArgs) {
+  return spawnSync(command, commandArgs, {
+    cwd: root,
+    env: process.env,
+    encoding: 'utf8',
+  });
+}
+
+function formatResult(label, status, detail) {
+  const icon = status === 'ok' ? '✓' : status === 'warn' ? '!' : '✗';
+  console.log(`${icon} ${label}: ${detail}`);
+}
+
+function parseMongoTarget(uri) {
+  try {
+    const normalized = uri.startsWith('mongodb+srv://') ? null : new URL(uri);
+    if (!normalized) {
+      return null;
+    }
+
+    return {
+      host: normalized.hostname || 'localhost',
+      port: Number(normalized.port || 27017),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function probeTcp(host, port) {
+  return new Promise((resolve) => {
+    const socket = net.createConnection({ host, port });
+    const done = (status, detail) => {
+      socket.destroy();
+      resolve({ status, detail });
+    };
+
+    socket.setTimeout(1500);
+    socket.on('connect', () => done('ok', `reachable at ${host}:${port}`));
+    socket.on('timeout', () => done('warn', `timed out while checking ${host}:${port}`));
+    socket.on('error', (error) => done('warn', error.message));
+  });
+}
+
+async function main() {
+  let hasFailure = false;
+
+  if (getNodeVersion() >= 18) {
+    formatResult('Node.js', 'ok', `v${process.versions.node}`);
+  } else {
+    hasFailure = true;
+    formatResult('Node.js', 'fail', `v${process.versions.node} detected, expected >= 18`);
+  }
+
+  const npmVersion = run('npm', ['--version']);
+  if (npmVersion.status === 0) {
+    formatResult('npm', 'ok', npmVersion.stdout.trim());
+  } else {
+    hasFailure = true;
+    formatResult('npm', 'fail', npmVersion.stderr.trim() || 'unable to read npm version');
+  }
+
+  if (fs.existsSync(envPath)) {
+    formatResult('.env', 'ok', 'root environment file detected');
+  } else {
+    hasFailure = true;
+    formatResult('.env', 'fail', 'root .env file is missing');
+  }
+
+  const missingRequired = requiredEnvVars.filter((name) => !process.env[name]?.trim());
+  if (missingRequired.length === 0) {
+    formatResult('Required secrets', 'ok', requiredEnvVars.join(', '));
+  } else {
+    hasFailure = true;
+    formatResult('Required secrets', 'fail', `missing ${missingRequired.join(', ')}`);
+  }
+
+  const missingOptional = optionalFeatureEnvVars.filter((name) => !process.env[name]?.trim());
+  if (missingOptional.length > 0) {
+    formatResult(
+      'Optional integrations',
+      'warn',
+      `not configured: ${missingOptional.join(', ')}`,
+    );
+  } else {
+    formatResult('Optional integrations', 'ok', 'Gemini and Stellar secrets configured');
+  }
+
+  const mongoTarget = parseMongoTarget(process.env.MONGO_URI || '');
+  if (!mongoTarget) {
+    formatResult(
+      'MongoDB check',
+      'warn',
+      'unable to parse MONGO_URI host/port automatically (mongodb+srv or custom syntax)',
+    );
+  } else {
+    const mongoProbe = await probeTcp(mongoTarget.host, mongoTarget.port);
+    formatResult('MongoDB check', mongoProbe.status, mongoProbe.detail);
+  }
+
+  if (args.has('--seed-demo')) {
+    const seedResult = run('npm', ['run', 'seed:demo', '-w', 'apps/api']);
+    if (seedResult.status === 0) {
+      formatResult('Demo seed', 'ok', 'seed script completed');
+    } else {
+      hasFailure = true;
+      formatResult('Demo seed', 'fail', seedResult.stderr.trim() || 'seed script failed');
+    }
+  } else {
+    formatResult('Demo seed', 'warn', 'skipped (pass --seed-demo to run it)');
+  }
+
+  if (hasFailure) {
+    process.exit(1);
+  }
+}
+
+void main();

--- a/packages/config/check-workspace-boundaries.cjs
+++ b/packages/config/check-workspace-boundaries.cjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = path.resolve(__dirname, '..', '..');
+const boundaryDefinitions = [
+  {
+    workspace: '@lumen/api',
+    path: 'apps/api',
+    canImport: ['@lumen/config', '@lumen/types'],
+  },
+  {
+    workspace: '@lumen/web',
+    path: 'apps/web',
+    canImport: ['@lumen/config', '@lumen/types'],
+  },
+  {
+    workspace: '@lumen/stellar',
+    path: 'apps/stellar-service',
+    canImport: ['@lumen/config'],
+  },
+  {
+    workspace: '@lumen/config',
+    path: 'packages/config',
+    canImport: [],
+  },
+  {
+    workspace: '@lumen/types',
+    path: 'packages/types',
+    canImport: [],
+  },
+];
+
+const fixtureMode = process.argv.includes('--fixtures');
+const fixtureRoot = path.join(__dirname, 'fixtures');
+const importPattern =
+  /\b(?:import|export)\s+(?:type\s+)?(?:[^'"]+from\s+)?["']([^"']+)["']|\brequire\(\s*["']([^"']+)["']\s*\)/g;
+
+function collectFiles(dir) {
+  if (!fs.existsSync(dir)) {
+    return [];
+  }
+
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  return entries.flatMap((entry) => {
+    const next = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (['node_modules', 'dist', '.next', '.turbo', '.git'].includes(entry.name)) {
+        return [];
+      }
+      return collectFiles(next);
+    }
+
+    if (!/\.(ts|tsx|js|jsx|mjs|cjs)$/.test(entry.name)) {
+      return [];
+    }
+
+    return [next];
+  });
+}
+
+function getBoundaryForFile(file) {
+  const relative = path.relative(root, file).replace(/\\/g, '/');
+  return boundaryDefinitions.find((boundary) => relative.startsWith(`${boundary.path}/`)) || null;
+}
+
+function resolveViolation(file, specifier) {
+  const boundary = getBoundaryForFile(file);
+  if (!boundary) {
+    return null;
+  }
+
+  if (specifier.startsWith('apps/') || specifier.startsWith('packages/')) {
+    return {
+      file,
+      specifier,
+      message: 'Cross-workspace root-relative imports are not allowed.',
+    };
+  }
+
+  if (specifier.startsWith('@lumen/')) {
+    if (specifier === boundary.workspace || boundary.canImport.includes(specifier)) {
+      return null;
+    }
+
+    return {
+      file,
+      specifier,
+      message: `${boundary.workspace} cannot import ${specifier}. Allowed shared packages: ${
+        boundary.canImport.join(', ') || 'none'
+      }.`,
+    };
+  }
+
+  if (specifier.startsWith('..')) {
+    const originDir = path.dirname(file);
+    const resolved = path.resolve(originDir, specifier);
+    const resolvedBoundary = getBoundaryForFile(resolved);
+    if (resolvedBoundary && resolvedBoundary.path !== boundary.path) {
+      return {
+        file,
+        specifier,
+        message: `Relative import escapes ${boundary.path} into ${resolvedBoundary.path}.`,
+      };
+    }
+  }
+
+  return null;
+}
+
+function scan(files) {
+  const violations = [];
+
+  for (const file of files) {
+    const content = fs.readFileSync(file, 'utf8');
+    for (const match of content.matchAll(importPattern)) {
+      const specifier = match[1] || match[2];
+      if (!specifier) {
+        continue;
+      }
+
+      const violation = resolveViolation(file, specifier);
+      if (violation) {
+        violations.push(violation);
+      }
+    }
+  }
+
+  return violations;
+}
+
+const roots = fixtureMode
+  ? [fixtureRoot]
+  : boundaryDefinitions.map((boundary) => path.join(root, boundary.path));
+
+const files = roots.flatMap((dir) => collectFiles(dir));
+const violations = scan(files);
+
+if (fixtureMode) {
+  if (violations.length === 0) {
+    console.error('Expected the fixture scan to report at least one boundary violation.');
+    process.exit(1);
+  }
+
+  console.log(`Fixture check surfaced ${violations.length} expected boundary violation(s).`);
+  for (const violation of violations) {
+    console.log(`- ${path.relative(root, violation.file)} :: ${violation.specifier}`);
+  }
+  process.exit(0);
+}
+
+if (violations.length > 0) {
+  console.error(`Workspace boundary check failed with ${violations.length} violation(s):`);
+  for (const violation of violations) {
+    console.error(`- ${path.relative(root, violation.file)} :: ${violation.specifier}`);
+    console.error(`  ${violation.message}`);
+  }
+  process.exit(1);
+}
+
+console.log('Workspace boundary check passed.');

--- a/packages/config/feature-flags.ts
+++ b/packages/config/feature-flags.ts
@@ -1,0 +1,73 @@
+export const featureFlagDefinitions = {
+  aiSummaries: {
+    key: 'aiSummaries',
+    env: 'LUMEN_FEATURE_AI_SUMMARIES',
+    publicEnv: 'NEXT_PUBLIC_LUMEN_FEATURE_AI_SUMMARIES',
+    defaultValue: true,
+    owner: 'clinical-intelligence',
+    description: 'Controls AI-assisted encounter summarization flows.',
+  },
+  stellarBilling: {
+    key: 'stellarBilling',
+    env: 'LUMEN_FEATURE_STELLAR_BILLING',
+    publicEnv: 'NEXT_PUBLIC_LUMEN_FEATURE_STELLAR_BILLING',
+    defaultValue: true,
+    owner: 'payments',
+    description: 'Controls Stellar payment and billing workflows.',
+  },
+  offlineMode: {
+    key: 'offlineMode',
+    env: 'LUMEN_FEATURE_OFFLINE_MODE',
+    publicEnv: 'NEXT_PUBLIC_LUMEN_FEATURE_OFFLINE_MODE',
+    defaultValue: false,
+    owner: 'mobile-platform',
+    description: 'Controls offline-first and queued sync experiences.',
+  },
+} as const;
+
+export type FeatureFlagKey = keyof typeof featureFlagDefinitions;
+
+export type FeatureFlags = Record<FeatureFlagKey, boolean>;
+
+type EnvReader = (name: string) => string | undefined;
+
+const truthy = new Set(['1', 'true', 'yes', 'on', 'enabled']);
+const falsy = new Set(['0', 'false', 'no', 'off', 'disabled']);
+
+export const parseBooleanFlag = (raw: string | undefined, fallback: boolean) => {
+  if (typeof raw !== 'string') {
+    return fallback;
+  }
+
+  const normalized = raw.trim().toLowerCase();
+  if (!normalized) {
+    return fallback;
+  }
+
+  if (truthy.has(normalized)) {
+    return true;
+  }
+
+  if (falsy.has(normalized)) {
+    return false;
+  }
+
+  return fallback;
+};
+
+const resolveFlagSet = (envReader: EnvReader, keyName: 'env' | 'publicEnv') => {
+  const entries = Object.entries(featureFlagDefinitions).map(([key, definition]) => {
+    const envName = definition[keyName];
+    return [key, parseBooleanFlag(envReader(envName), definition.defaultValue)];
+  });
+
+  return Object.fromEntries(entries) as FeatureFlags;
+};
+
+export const resolveServerFeatureFlags = (envReader: EnvReader = (name) => process.env[name]) =>
+  resolveFlagSet(envReader, 'env');
+
+export const resolvePublicFeatureFlags = (envReader: EnvReader = (name) => process.env[name]) =>
+  resolveFlagSet(envReader, 'publicEnv');
+
+export const isFeatureFlagEnabled = (flags: FeatureFlags, key: FeatureFlagKey) => flags[key];

--- a/packages/config/fixtures/invalid-cross-workspace-import.ts
+++ b/packages/config/fixtures/invalid-cross-workspace-import.ts
@@ -1,0 +1,7 @@
+import { config } from '@lumen/config';
+import { apiFetch } from '../../../apps/web/lib/api-client';
+
+export const fixture = {
+  apiBaseUrl: config.public.apiBaseUrl,
+  apiFetch,
+};

--- a/packages/config/index.ts
+++ b/packages/config/index.ts
@@ -1,10 +1,51 @@
 import dotenv from 'dotenv';
 import path from 'path';
+import {
+  FeatureFlags,
+  resolveServerFeatureFlags,
+} from './feature-flags';
+import {
+  getPublicRuntimeConfig,
+  PublicRuntimeConfig,
+} from './public';
+import { workspaceBoundarySummary } from './workspace-boundaries';
 
 dotenv.config({ path: path.resolve(__dirname, '../../.env') });
 
+type ConfigDiagnostic = {
+  name: string;
+  status: 'present' | 'missing' | 'defaulted';
+  source: 'env' | 'default';
+  valuePreview: string;
+};
+
+type ServerConfig = {
+  port: number;
+  mongoUri: string;
+  jwt: {
+    accessTokenSecret: string;
+    refreshTokenSecret: string;
+  };
+  stellar: {
+    network: string;
+    horizonUrl: string;
+    platformPublicKey: string;
+    platformSecretKey: string;
+  };
+  gemini: {
+    apiKey: string;
+    model: string;
+  };
+  public: PublicRuntimeConfig;
+  featureFlags: FeatureFlags;
+};
+
+const integerPattern = /^\d+$/;
+
+const getEnv = (name: string) => process.env[name]?.trim();
+
 const requireEnv = (name: string) => {
-  const value = process.env[name]?.trim();
+  const value = getEnv(name);
   if (!value) {
     throw new Error(`[config] Missing required environment variable: ${name}`);
   }
@@ -12,20 +53,110 @@ const requireEnv = (name: string) => {
   return value;
 };
 
-const optionalEnv = (name: string, fallback = '') => process.env[name]?.trim() || fallback;
+const optionalEnv = (name: string, fallback = '') => getEnv(name) || fallback;
 
-export const config = {
-  port: process.env.MONGO_URI || process.env.API_PORT || 4000,
+const parsePort = () => {
+  const raw = optionalEnv('API_PORT', '4000');
+  if (!integerPattern.test(raw)) {
+    throw new Error(`[config] API_PORT must be a whole number. Received: ${raw}`);
+  }
 
+  const value = Number(raw);
+  if (value < 1 || value > 65535) {
+    throw new Error(`[config] API_PORT must be between 1 and 65535. Received: ${value}`);
+  }
+
+  return value;
+};
+
+const buildDiagnostics = (): ConfigDiagnostic[] => {
+  const diagnosticEnv = [
+    ['API_PORT', optionalEnv('API_PORT', '4000'), 'default', '4000'],
+    ['MONGO_URI', getEnv('MONGO_URI') || '', 'env', ''],
+    ['JWT_ACCESS_TOKEN_SECRET', getEnv('JWT_ACCESS_TOKEN_SECRET') || '', 'env', ''],
+    ['JWT_REFRESH_TOKEN_SECRET', getEnv('JWT_REFRESH_TOKEN_SECRET') || '', 'env', ''],
+    ['STELLAR_NETWORK', optionalEnv('STELLAR_NETWORK', 'testnet'), 'default', 'testnet'],
+    [
+      'STELLAR_HORIZON_URL',
+      optionalEnv('STELLAR_HORIZON_URL', 'https://horizon-testnet.stellar.org'),
+      'default',
+      'https://horizon-testnet.stellar.org',
+    ],
+    ['STELLAR_PLATFORM_PUBLIC_KEY', getEnv('STELLAR_PLATFORM_PUBLIC_KEY') || '', 'env', ''],
+    ['STELLAR_SECRET_KEY', getEnv('STELLAR_SECRET_KEY') || '', 'env', ''],
+    ['GEMINI_API_KEY', getEnv('GEMINI_API_KEY') || '', 'env', ''],
+    ['GEMINI_MODEL', optionalEnv('GEMINI_MODEL', 'gemini-1.5-flash'), 'default', 'gemini-1.5-flash'],
+    [
+      'NEXT_PUBLIC_API_BASE_URL',
+      optionalEnv('NEXT_PUBLIC_API_BASE_URL', 'http://localhost:4000/api/v1'),
+      'default',
+      'http://localhost:4000/api/v1',
+    ],
+  ] as const;
+
+  return diagnosticEnv.map(([name, value, preferredSource, defaultValue]) => {
+    if (!value) {
+      return {
+        name,
+        status: 'missing',
+        source: 'env',
+        valuePreview: '',
+      };
+    }
+
+    const isDefaulted = preferredSource === 'default' && value === defaultValue;
+    return {
+      name,
+      status: isDefaulted ? 'defaulted' : 'present',
+      source: isDefaulted ? 'default' : 'env',
+      valuePreview:
+        name.includes('SECRET') || name.includes('KEY')
+          ? `${value.slice(0, 4)}***`
+          : value,
+    };
+  });
+};
+
+export const getConfigDiagnostics = () => ({
+  environment: buildDiagnostics(),
+  workspaceBoundaries: workspaceBoundarySummary,
+});
+
+export const createServerConfig = (): ServerConfig => ({
+  port: parsePort(),
   mongoUri: requireEnv('MONGO_URI'),
   jwt: {
     accessTokenSecret: requireEnv('JWT_ACCESS_TOKEN_SECRET'),
     refreshTokenSecret: requireEnv('JWT_REFRESH_TOKEN_SECRET'),
   },
   stellar: {
-    network: optionalEnv('STELLAR_NETWORK', 'testnet'),
-    horizonUrl:
-      optionalEnv('STELLAR_HORIZON_URL', 'https://horizon-testnet.stellar.org'),
+    network: optionalEnv('STELLAR_NETWORK', 'testnet').toUpperCase(),
+    horizonUrl: optionalEnv('STELLAR_HORIZON_URL', 'https://horizon-testnet.stellar.org'),
     platformPublicKey: optionalEnv('STELLAR_PLATFORM_PUBLIC_KEY'),
+    platformSecretKey: optionalEnv('STELLAR_SECRET_KEY'),
   },
-};
+  gemini: {
+    apiKey: optionalEnv('GEMINI_API_KEY'),
+    model: optionalEnv('GEMINI_MODEL', 'gemini-1.5-flash'),
+  },
+  public: getPublicRuntimeConfig(),
+  featureFlags: resolveServerFeatureFlags(getEnv),
+});
+
+export const config = createServerConfig();
+
+export { getPublicRuntimeConfig } from './public';
+export {
+  featureFlagDefinitions,
+  isFeatureFlagEnabled,
+  parseBooleanFlag,
+  resolvePublicFeatureFlags,
+  resolveServerFeatureFlags,
+} from './feature-flags';
+export {
+  workspaceBoundaries,
+  workspaceBoundaryMap,
+  workspaceBoundarySummary,
+} from './workspace-boundaries';
+export type { FeatureFlagKey, FeatureFlags } from './feature-flags';
+export type { PublicRuntimeConfig } from './public';

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,10 +1,16 @@
 {
   "name": "@lumen/config",
   "version": "1.0.0",
-  "main": "index.js",
+  "main": "index.ts",
+  "exports": {
+    ".": "./index.ts",
+    "./public": "./public.ts",
+    "./feature-flags": "./feature-flags.ts",
+    "./workspace-boundaries": "./workspace-boundaries.ts"
+  },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "main": "index.ts"
+    "check:boundaries": "node check-workspace-boundaries.cjs",
+    "check:boundaries:fixtures": "node check-workspace-boundaries.cjs --fixtures"
   },
   "keywords": [],
   "author": "",

--- a/packages/config/public.ts
+++ b/packages/config/public.ts
@@ -1,0 +1,18 @@
+import {
+  FeatureFlags,
+  resolvePublicFeatureFlags,
+} from './feature-flags';
+
+export type PublicRuntimeConfig = {
+  apiBaseUrl: string;
+  featureFlags: FeatureFlags;
+};
+
+const getEnv = (name: string) => process.env[name]?.trim();
+
+export const getPublicRuntimeConfig = (): PublicRuntimeConfig => ({
+  apiBaseUrl: getEnv('NEXT_PUBLIC_API_BASE_URL') || 'http://localhost:4000/api/v1',
+  featureFlags: resolvePublicFeatureFlags(getEnv),
+});
+
+export const publicConfig = getPublicRuntimeConfig();

--- a/packages/config/workspace-boundaries.ts
+++ b/packages/config/workspace-boundaries.ts
@@ -1,0 +1,63 @@
+export type WorkspaceBoundary = {
+  workspace: string;
+  path: string;
+  owner: string;
+  runtime: 'backend' | 'frontend' | 'service' | 'shared';
+  canImport: string[];
+  description: string;
+};
+
+export const workspaceBoundaries: WorkspaceBoundary[] = [
+  {
+    workspace: '@lumen/api',
+    path: 'apps/api',
+    owner: 'backend-platform',
+    runtime: 'backend',
+    canImport: ['@lumen/config', '@lumen/types'],
+    description: 'Express modular monolith for clinic, patient, workflow, billing, and AI routes.',
+  },
+  {
+    workspace: '@lumen/web',
+    path: 'apps/web',
+    owner: 'web-platform',
+    runtime: 'frontend',
+    canImport: ['@lumen/config', '@lumen/types'],
+    description: 'Next.js clinic dashboard and authenticated operator interface.',
+  },
+  {
+    workspace: '@lumen/stellar',
+    path: 'apps/stellar-service',
+    owner: 'payments-platform',
+    runtime: 'service',
+    canImport: ['@lumen/config'],
+    description: 'Isolated Stellar wallet, verification, and diagnostics service.',
+  },
+  {
+    workspace: '@lumen/config',
+    path: 'packages/config',
+    owner: 'platform-foundation',
+    runtime: 'shared',
+    canImport: [],
+    description: 'Shared configuration contracts, runtime flags, and boundary tooling.',
+  },
+  {
+    workspace: '@lumen/types',
+    path: 'packages/types',
+    owner: 'platform-foundation',
+    runtime: 'shared',
+    canImport: [],
+    description: 'Shared schemas and type contracts.',
+  },
+];
+
+export const workspaceBoundaryMap = new Map(
+  workspaceBoundaries.map((boundary) => [boundary.path, boundary]),
+);
+
+export const workspaceBoundarySummary = workspaceBoundaries.map((boundary) => ({
+  workspace: boundary.workspace,
+  path: boundary.path,
+  runtime: boundary.runtime,
+  owner: boundary.owner,
+  canImport: boundary.canImport,
+}));


### PR DESCRIPTION
## Included
- add workspace boundary ownership metadata and boundary verification tooling
- add deterministic local bootstrap and optional demo seed orchestration
- centralize typed runtime config and environment diagnostics in `@lumen/config`
- add typed feature flag registry with API and web integration
- inject public runtime config into the web app and unify API base URL access
- document boundary and bootstrap workflows in README

## Validation
- passed `node packages/config/check-workspace-boundaries.cjs`
- passed `node packages/config/check-workspace-boundaries.cjs --fixtures`
- ran `node packages/config/bootstrap.cjs` and confirmed expected failure output when `.env` is absent
- web/api full build-test flow blocked locally because `next` and `vitest` are not installed in this environment

## Notes
- local `.gitignore` change was intentionally left uncommitted
- preparatory backlog/import artifacts were not included in this branch

closes #280
closes #281
closes #282
closes #283