### PR TITLE
feat(api): CHORD-025/026/027/028 — backend platform hardening

### DIFF
--- a/apps/api/src/app.factory.ts
+++ b/apps/api/src/app.factory.ts
@@ -1,7 +1,9 @@
 import cors from 'cors';
 import express, { Express } from 'express';
-import { config, getConfigDiagnostics } from '@lumen/config';
+import { config } from '@lumen/config';
+import { antiAbuseMiddleware } from './middlewares/anti-abuse.middleware';
 import { auditMiddleware } from './middlewares/audit.middleware';
+import { authRateLimiter, mutationRateLimiter } from './middlewares/rate-limit.middleware';
 import { errorMiddleware } from './middlewares/error.middleware';
 import { requestContextMiddleware } from './middlewares/request-context.middleware';
 import { requireActiveSubscription } from './middlewares/subscription.middleware';
@@ -13,6 +15,7 @@ import { clinicOnboardingRoutes } from './modules/clinics/onboarding.controller'
 import { clinicSettingsRoutes } from './modules/clinics/settings.controller';
 import { diagnosisRoutes } from './modules/diagnoses/diagnoses.controller';
 import { encounterRoutes } from './modules/encounters/encounters.controller';
+import { healthRoutes } from './modules/health/health.controller';
 import { notesRoutes } from './modules/notes/notes.controller';
 import { patientHistoryRoutes } from './modules/patients/history.controller';
 import { patientRoutes } from './modules/patients/patients.controller';
@@ -20,9 +23,13 @@ import { paymentRoutes } from './modules/payments/payments.controller';
 import { queueRoutes } from './modules/queue/queue.controller';
 import { userRoutes } from './modules/users/users.controller';
 import { vitalsRoutes } from './modules/vitals/vitals.controller';
+import { registrationAbuseGuard } from './middlewares/anti-abuse.middleware';
 
 export const createApp = (): Express => {
   const app = express();
+
+  // Global guards (run before body parsing to catch oversized payloads early)
+  app.use(...antiAbuseMiddleware);
 
   app.use(cors());
   app.use(express.json());
@@ -30,9 +37,19 @@ export const createApp = (): Express => {
   app.use(auditMiddleware);
   app.use(requireActiveSubscription);
 
-  app.use('/api/v1/auth', authRoutes);
-  app.use('/api/v1/clinics', clinicOnboardingRoutes);
+  // Health / readiness / diagnostics (no auth, no rate limiting)
+  app.use(healthRoutes);
+
+  // Auth routes — strict rate limiting
+  app.use('/api/v1/auth', authRateLimiter, authRoutes);
+
+  // Clinic registration — auth rate limit + registration abuse guard
+  app.use('/api/v1/clinics', authRateLimiter, registrationAbuseGuard, clinicOnboardingRoutes);
   app.use('/api/v1/clinics', clinicSettingsRoutes);
+
+  // Mutation rate limiting on all state-changing API routes
+  app.use('/api/v1', mutationRateLimiter);
+
   app.use('/api/v1/users', userRoutes);
   if (config.featureFlags.stellarBilling) {
     app.use('/api/v1/payments', paymentRoutes);
@@ -49,20 +66,6 @@ export const createApp = (): Express => {
   app.use('/api/v1/encounters', encounterRoutes);
   app.use('/api/v1/notes', notesRoutes);
   app.use('/api/v1/audit-logs', auditRoutes);
-
-  app.get('/health', (_req, res) => {
-    const diagnostics = getConfigDiagnostics();
-    res.json({
-      status: 'ok',
-      timestamp: new Date(),
-      featureFlags: config.featureFlags,
-      diagnostics: {
-        present: diagnostics.environment.filter((item) => item.status === 'present').length,
-        missing: diagnostics.environment.filter((item) => item.status === 'missing').length,
-        defaulted: diagnostics.environment.filter((item) => item.status === 'defaulted').length,
-      },
-    });
-  });
 
   app.use(errorMiddleware);
 

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,12 +1,17 @@
 import { config } from '@lumen/config';
 import { connectDB } from './config/db';
 import { createApp } from './app.factory';
+import { setupGracefulShutdown } from './shutdown';
 import { startPaymentVerificationWorker } from './modules/payments/worker';
 import { startCdsWorker } from './modules/ai/cds.worker';
+
+export { setupGracefulShutdown } from './shutdown';
+
 const app = createApp();
 
 const start = async () => {
   await connectDB();
+
   if (config.featureFlags.stellarBilling) {
     startPaymentVerificationWorker();
   }
@@ -14,9 +19,11 @@ const start = async () => {
     startCdsWorker();
   }
 
-  app.listen(config.port, () => {
+  const server = app.listen(config.port, () => {
     console.log(`🚀 API running on http://localhost:${config.port}`);
   });
+
+  setupGracefulShutdown(server);
 };
 
 void start();

--- a/apps/api/src/middlewares/anti-abuse.middleware.ts
+++ b/apps/api/src/middlewares/anti-abuse.middleware.ts
@@ -1,0 +1,117 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+/**
+ * Detects and blocks suspicious request patterns:
+ * - Oversized payloads (beyond express.json limit, belt-and-suspenders check)
+ * - Malformed or missing Content-Type on POST/PUT/PATCH
+ * - Suspiciously large query strings (path traversal / injection probes)
+ * - Null-byte injection in URL
+ * - Repeated rapid registration attempts from the same IP (credential stuffing signal)
+ */
+
+const MAX_BODY_BYTES = 1_048_576; // 1 MB
+const MAX_QUERY_LENGTH = 2_048;
+
+interface AbuseEntry {
+  count: number;
+  resetAt: number;
+}
+
+const registrationAttempts = new Map<string, AbuseEntry>();
+const REGISTRATION_WINDOW_MS = 60 * 60 * 1000; // 1 hour
+const MAX_REGISTRATIONS_PER_HOUR = 5;
+
+// Cleanup stale entries periodically
+const cleanup = setInterval(() => {
+  const now = Date.now();
+  for (const [key, entry] of registrationAttempts) {
+    if (entry.resetAt <= now) registrationAttempts.delete(key);
+  }
+}, REGISTRATION_WINDOW_MS);
+cleanup.unref();
+
+function getIp(req: Request): string {
+  return req.ip ?? 'unknown';
+}
+
+/** Rejects requests with null bytes in the URL (common injection probe). */
+export const nullByteGuard: RequestHandler = (req: Request, res: Response, next: NextFunction): void => {
+  if (req.url.includes('\0')) {
+    res.status(400).json({
+      status: 'error',
+      error: { code: 'BAD_REQUEST', message: 'Invalid request.' },
+    });
+    return;
+  }
+  next();
+};
+
+/** Rejects oversized query strings. */
+export const queryLengthGuard: RequestHandler = (req: Request, res: Response, next: NextFunction): void => {
+  const qs = req.url.split('?')[1] ?? '';
+  if (qs.length > MAX_QUERY_LENGTH) {
+    res.status(400).json({
+      status: 'error',
+      error: { code: 'BAD_REQUEST', message: 'Query string too large.' },
+    });
+    return;
+  }
+  next();
+};
+
+/** Rejects mutation requests with a body that exceeds the size cap. */
+export const bodySizeGuard: RequestHandler = (req: Request, res: Response, next: NextFunction): void => {
+  const mutationMethods = ['POST', 'PUT', 'PATCH'];
+  if (!mutationMethods.includes(req.method)) {
+    next();
+    return;
+  }
+
+  const contentLength = parseInt(req.headers['content-length'] ?? '0', 10);
+  if (contentLength > MAX_BODY_BYTES) {
+    res.status(413).json({
+      status: 'error',
+      error: { code: 'PAYLOAD_TOO_LARGE', message: 'Request body too large.' },
+    });
+    return;
+  }
+  next();
+};
+
+/**
+ * Tracks registration attempts per IP.
+ * Apply only to POST /api/v1/clinics (clinic registration) and POST /api/v1/auth/register.
+ */
+export const registrationAbuseGuard: RequestHandler = (req: Request, res: Response, next: NextFunction): void => {
+  const ip = getIp(req);
+  const now = Date.now();
+
+  let entry = registrationAttempts.get(ip);
+  if (!entry || entry.resetAt <= now) {
+    entry = { count: 0, resetAt: now + REGISTRATION_WINDOW_MS };
+    registrationAttempts.set(ip, entry);
+  }
+
+  entry.count += 1;
+
+  if (entry.count > MAX_REGISTRATIONS_PER_HOUR) {
+    console.warn('[anti-abuse] High-frequency registration attempt blocked', { ip, count: entry.count });
+    res.status(429).json({
+      status: 'error',
+      error: { code: 'RATE_LIMITED', message: 'Too many registration attempts. Please try again later.' },
+    });
+    return;
+  }
+
+  next();
+};
+
+/**
+ * Composite anti-abuse middleware — apply globally before routes.
+ * Combines null-byte, query-length, and body-size guards.
+ */
+export const antiAbuseMiddleware: RequestHandler[] = [
+  nullByteGuard,
+  queryLengthGuard,
+  bodySizeGuard,
+];

--- a/apps/api/src/middlewares/rate-limit.middleware.ts
+++ b/apps/api/src/middlewares/rate-limit.middleware.ts
@@ -1,0 +1,80 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+interface RateLimitOptions {
+  /** Window size in milliseconds */
+  windowMs: number;
+  /** Max requests per window per key */
+  max: number;
+  /** Derive the key from the request (defaults to IP) */
+  keyFn?: (req: Request) => string;
+  /** Message sent when limit is exceeded */
+  message?: string;
+}
+
+interface WindowEntry {
+  count: number;
+  resetAt: number;
+}
+
+/**
+ * Minimal in-memory rate limiter.
+ * Each instance maintains its own counter store — suitable for single-process deployments.
+ */
+export function createRateLimiter(options: RateLimitOptions): RequestHandler {
+  const { windowMs, max, message = 'Too many requests, please try again later.' } = options;
+  const keyFn = options.keyFn ?? ((req) => req.ip ?? 'unknown');
+
+  const store = new Map<string, WindowEntry>();
+
+  // Periodic cleanup to prevent unbounded memory growth
+  const cleanup = setInterval(() => {
+    const now = Date.now();
+    for (const [key, entry] of store) {
+      if (entry.resetAt <= now) store.delete(key);
+    }
+  }, windowMs);
+  cleanup.unref();
+
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const key = keyFn(req);
+    const now = Date.now();
+
+    let entry = store.get(key);
+    if (!entry || entry.resetAt <= now) {
+      entry = { count: 0, resetAt: now + windowMs };
+      store.set(key, entry);
+    }
+
+    entry.count += 1;
+
+    const remaining = Math.max(0, max - entry.count);
+    res.setHeader('X-RateLimit-Limit', max);
+    res.setHeader('X-RateLimit-Remaining', remaining);
+    res.setHeader('X-RateLimit-Reset', Math.ceil(entry.resetAt / 1000));
+
+    if (entry.count > max) {
+      res.setHeader('Retry-After', Math.ceil((entry.resetAt - now) / 1000));
+      res.status(429).json({
+        status: 'error',
+        error: { code: 'RATE_LIMITED', message },
+      });
+      return;
+    }
+
+    next();
+  };
+}
+
+/** Strict limiter for auth endpoints (login, register, password reset) */
+export const authRateLimiter = createRateLimiter({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 20,
+  message: 'Too many authentication attempts. Please try again in 15 minutes.',
+});
+
+/** Moderate limiter for state-mutating routes (POST/PUT/PATCH/DELETE) */
+export const mutationRateLimiter = createRateLimiter({
+  windowMs: 60 * 1000, // 1 minute
+  max: 60,
+  message: 'Too many requests. Please slow down.',
+});

--- a/apps/api/src/modules/health/health.controller.ts
+++ b/apps/api/src/modules/health/health.controller.ts
@@ -1,0 +1,92 @@
+import { Router } from 'express';
+import mongoose from 'mongoose';
+import { config, getConfigDiagnostics } from '@lumen/config';
+
+const router = Router();
+
+type DepStatus = 'ok' | 'degraded' | 'unavailable';
+
+interface DepCheck {
+  name: string;
+  status: DepStatus;
+  latencyMs?: number;
+  detail?: string;
+}
+
+async function checkMongo(): Promise<DepCheck> {
+  const start = Date.now();
+  try {
+    const state = mongoose.connection.readyState;
+    // 1 = connected
+    if (state !== 1) {
+      return { name: 'mongodb', status: 'unavailable', detail: `readyState=${state}` };
+    }
+    // Ping to confirm the connection is live
+    await mongoose.connection.db?.admin().ping();
+    return { name: 'mongodb', status: 'ok', latencyMs: Date.now() - start };
+  } catch (err) {
+    return {
+      name: 'mongodb',
+      status: 'unavailable',
+      latencyMs: Date.now() - start,
+      detail: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+/**
+ * GET /health
+ * Liveness probe — always returns 200 if the process is running.
+ * Replaces the basic /health in app.factory.ts.
+ */
+router.get('/health', (_req, res) => {
+  res.json({
+    status: 'ok',
+    timestamp: new Date().toISOString(),
+    uptime: process.uptime(),
+    featureFlags: config.featureFlags,
+  });
+});
+
+/**
+ * GET /ready
+ * Readiness probe — returns 200 only when all critical dependencies are reachable.
+ * Kubernetes / load-balancer should use this before routing traffic.
+ */
+router.get('/ready', async (_req, res) => {
+  const mongo = await checkMongo();
+  const allOk = mongo.status === 'ok';
+
+  res.status(allOk ? 200 : 503).json({
+    status: allOk ? 'ready' : 'not_ready',
+    timestamp: new Date().toISOString(),
+    dependencies: [mongo],
+  });
+});
+
+/**
+ * GET /diagnostics
+ * Full dependency + config diagnostics. Intended for internal/ops use.
+ */
+router.get('/diagnostics', async (_req, res) => {
+  const [mongo] = await Promise.all([checkMongo()]);
+  const configDiag = getConfigDiagnostics();
+
+  res.json({
+    status: 'ok',
+    timestamp: new Date().toISOString(),
+    dependencies: [mongo],
+    config: {
+      present: configDiag.environment.filter((e) => e.status === 'present').length,
+      missing: configDiag.environment.filter((e) => e.status === 'missing').length,
+      defaulted: configDiag.environment.filter((e) => e.status === 'defaulted').length,
+      entries: configDiag.environment.map(({ name, status, valuePreview }) => ({
+        name,
+        status,
+        valuePreview,
+      })),
+    },
+  });
+});
+
+export { router as healthRoutes };

--- a/apps/api/src/shutdown.ts
+++ b/apps/api/src/shutdown.ts
@@ -1,0 +1,43 @@
+import mongoose from 'mongoose';
+import type { Server } from 'http';
+
+const SHUTDOWN_TIMEOUT_MS = 10_000;
+
+export function setupGracefulShutdown(server: Server): void {
+  let shuttingDown = false;
+
+  const shutdown = async (signal: string) => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+
+    console.log(`[shutdown] Received ${signal}. Starting graceful shutdown...`);
+
+    const forceExit = setTimeout(() => {
+      console.error('[shutdown] Graceful shutdown timed out. Forcing exit.');
+      process.exit(1);
+    }, SHUTDOWN_TIMEOUT_MS);
+    forceExit.unref();
+
+    server.close(async (err) => {
+      if (err) {
+        console.error('[shutdown] Error closing HTTP server:', err);
+      } else {
+        console.log('[shutdown] HTTP server closed.');
+      }
+
+      try {
+        await mongoose.disconnect();
+        console.log('[shutdown] MongoDB disconnected.');
+      } catch (dbErr) {
+        console.error('[shutdown] Error disconnecting MongoDB:', dbErr);
+      }
+
+      clearTimeout(forceExit);
+      console.log('[shutdown] Graceful shutdown complete.');
+      process.exit(0);
+    });
+  };
+
+  process.on('SIGTERM', () => void shutdown('SIGTERM'));
+  process.on('SIGINT', () => void shutdown('SIGINT'));
+}

--- a/apps/api/tests/anti-abuse.middleware.test.ts
+++ b/apps/api/tests/anti-abuse.middleware.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  nullByteGuard,
+  queryLengthGuard,
+  bodySizeGuard,
+  registrationAbuseGuard,
+} from '../src/middlewares/anti-abuse.middleware';
+import type { Request, Response, NextFunction } from 'express';
+
+const makeReq = (overrides: Partial<Request> = {}): Request =>
+  ({
+    url: '/api/v1/test',
+    method: 'GET',
+    ip: '127.0.0.1',
+    headers: {},
+    ...overrides,
+  } as unknown as Request);
+
+const makeRes = () => {
+  const res = {
+    _status: 200,
+    _body: null as unknown,
+    status: vi.fn().mockImplementation(function (this: ReturnType<typeof makeRes>, code: number) {
+      this._status = code;
+      return this;
+    }),
+    json: vi.fn().mockImplementation(function (this: ReturnType<typeof makeRes>, body: unknown) {
+      this._body = body;
+      return this;
+    }),
+  };
+  res.status = res.status.bind(res);
+  res.json = res.json.bind(res);
+  return res as unknown as Response & { _status: number; _body: unknown };
+};
+
+describe('CHORD-027 anti-abuse middleware', () => {
+  describe('nullByteGuard', () => {
+    it('passes clean URLs', () => {
+      const next = vi.fn() as unknown as NextFunction;
+      nullByteGuard(makeReq({ url: '/api/v1/patients' }), makeRes(), next);
+      expect(next).toHaveBeenCalledOnce();
+    });
+
+    it('blocks URLs with null bytes', () => {
+      const next = vi.fn() as unknown as NextFunction;
+      const res = makeRes();
+      nullByteGuard(makeReq({ url: '/api/v1/patients\0evil' }), res, next);
+      expect(next).not.toHaveBeenCalled();
+      expect(res._status).toBe(400);
+    });
+  });
+
+  describe('queryLengthGuard', () => {
+    it('passes short query strings', () => {
+      const next = vi.fn() as unknown as NextFunction;
+      queryLengthGuard(makeReq({ url: '/api/v1/patients?name=John' }), makeRes(), next);
+      expect(next).toHaveBeenCalledOnce();
+    });
+
+    it('blocks oversized query strings', () => {
+      const next = vi.fn() as unknown as NextFunction;
+      const res = makeRes();
+      const longQuery = 'a'.repeat(3000);
+      queryLengthGuard(makeReq({ url: `/api/v1/patients?q=${longQuery}` }), res, next);
+      expect(next).not.toHaveBeenCalled();
+      expect(res._status).toBe(400);
+    });
+  });
+
+  describe('bodySizeGuard', () => {
+    it('passes GET requests regardless of content-length', () => {
+      const next = vi.fn() as unknown as NextFunction;
+      bodySizeGuard(
+        makeReq({ method: 'GET', headers: { 'content-length': '9999999' } }),
+        makeRes(),
+        next,
+      );
+      expect(next).toHaveBeenCalledOnce();
+    });
+
+    it('passes POST with acceptable body size', () => {
+      const next = vi.fn() as unknown as NextFunction;
+      bodySizeGuard(
+        makeReq({ method: 'POST', headers: { 'content-length': '512' } }),
+        makeRes(),
+        next,
+      );
+      expect(next).toHaveBeenCalledOnce();
+    });
+
+    it('blocks POST with oversized body', () => {
+      const next = vi.fn() as unknown as NextFunction;
+      const res = makeRes();
+      bodySizeGuard(
+        makeReq({ method: 'POST', headers: { 'content-length': '2000000' } }),
+        res,
+        next,
+      );
+      expect(next).not.toHaveBeenCalled();
+      expect(res._status).toBe(413);
+    });
+  });
+
+  describe('registrationAbuseGuard', () => {
+    it('allows registrations under the threshold', () => {
+      const next = vi.fn() as unknown as NextFunction;
+      // Use a unique IP to avoid state from other tests
+      const req = makeReq({ ip: '192.168.99.1', method: 'POST' });
+      registrationAbuseGuard(req, makeRes(), next);
+      expect(next).toHaveBeenCalledOnce();
+    });
+
+    it('blocks excessive registrations from the same IP', () => {
+      const ip = '192.168.99.2';
+      const next = vi.fn() as unknown as NextFunction;
+
+      // Exhaust the limit (5 per hour)
+      for (let i = 0; i < 5; i++) {
+        registrationAbuseGuard(makeReq({ ip, method: 'POST' }), makeRes(), next);
+      }
+
+      const res = makeRes();
+      registrationAbuseGuard(makeReq({ ip, method: 'POST' }), res, next);
+      expect(res._status).toBe(429);
+    });
+  });
+});

--- a/apps/api/tests/graceful-shutdown.test.ts
+++ b/apps/api/tests/graceful-shutdown.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupGracefulShutdown } from '../src/shutdown';
+
+describe('CHORD-025 graceful shutdown', () => {
+  let processOnSpy: ReturnType<typeof vi.spyOn>;
+  const handlers: Record<string, (...args: unknown[]) => void> = {};
+
+  beforeEach(() => {
+    processOnSpy = vi.spyOn(process, 'on').mockImplementation((event, handler) => {
+      handlers[event as string] = handler as (...args: unknown[]) => void;
+      return process;
+    });
+  });
+
+  afterEach(() => {
+    processOnSpy.mockRestore();
+    vi.restoreAllMocks();
+  });
+
+  it('registers SIGTERM and SIGINT handlers', () => {
+    const fakeServer = { close: vi.fn() } as unknown as import('http').Server;
+    setupGracefulShutdown(fakeServer);
+
+    expect(handlers['SIGTERM']).toBeDefined();
+    expect(handlers['SIGINT']).toBeDefined();
+  });
+
+  it('calls server.close on SIGTERM', () => {
+    const fakeServer = { close: vi.fn() } as unknown as import('http').Server;
+    setupGracefulShutdown(fakeServer);
+
+    handlers['SIGTERM']?.();
+
+    expect(fakeServer.close).toHaveBeenCalledOnce();
+  });
+
+  it('does not call server.close twice when signal fires multiple times', () => {
+    const fakeServer = { close: vi.fn() } as unknown as import('http').Server;
+    setupGracefulShutdown(fakeServer);
+
+    handlers['SIGTERM']?.();
+    handlers['SIGTERM']?.();
+
+    expect(fakeServer.close).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/api/tests/health.controller.test.ts
+++ b/apps/api/tests/health.controller.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock mongoose before importing the health controller
+vi.mock('mongoose', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('mongoose')>();
+  return {
+    ...actual,
+    default: {
+      ...actual.default,
+      connection: {
+        readyState: 1,
+        db: {
+          admin: () => ({ ping: vi.fn().mockResolvedValue({ ok: 1 }) }),
+        },
+      },
+    },
+  };
+});
+
+describe('CHORD-028 health endpoints', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env.API_PORT = '4000';
+    process.env.MONGO_URI = 'mongodb://localhost:27017/lumenhealth-test';
+    process.env.JWT_ACCESS_TOKEN_SECRET = 'access-secret';
+    process.env.JWT_REFRESH_TOKEN_SECRET = 'refresh-secret';
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.restoreAllMocks();
+  });
+
+  async function startTestServer() {
+    const express = (await import('express')).default;
+    const { healthRoutes } = await import('../src/modules/health/health.controller');
+    const app = express();
+    app.use(healthRoutes);
+
+    const server = await new Promise<import('http').Server>((resolve) => {
+      const s = app.listen(0, () => resolve(s));
+    });
+
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('Bad address');
+    const base = `http://127.0.0.1:${address.port}`;
+
+    const stop = () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      );
+
+    return { base, stop };
+  }
+
+  it('GET /health returns 200 with status ok', async () => {
+    const { base, stop } = await startTestServer();
+    try {
+      const res = await fetch(`${base}/health`);
+      const body = (await res.json()) as { status: string; uptime: number };
+      expect(res.status).toBe(200);
+      expect(body.status).toBe('ok');
+      expect(typeof body.uptime).toBe('number');
+    } finally {
+      await stop();
+    }
+  });
+
+  it('GET /ready returns 200 when mongo is connected', async () => {
+    const { base, stop } = await startTestServer();
+    try {
+      const res = await fetch(`${base}/ready`);
+      const body = (await res.json()) as { status: string; dependencies: { name: string; status: string }[] };
+      expect(res.status).toBe(200);
+      expect(body.status).toBe('ready');
+      expect(body.dependencies[0].name).toBe('mongodb');
+      expect(body.dependencies[0].status).toBe('ok');
+    } finally {
+      await stop();
+    }
+  });
+
+  it('GET /ready returns 503 when mongo is disconnected', async () => {
+    vi.doMock('mongoose', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('mongoose')>();
+      return {
+        ...actual,
+        default: {
+          ...actual.default,
+          connection: { readyState: 0, db: null },
+        },
+      };
+    });
+    vi.resetModules();
+
+    const express = (await import('express')).default;
+    const { healthRoutes } = await import('../src/modules/health/health.controller');
+    const app = express();
+    app.use(healthRoutes);
+
+    const server = await new Promise<import('http').Server>((resolve) => {
+      const s = app.listen(0, () => resolve(s));
+    });
+    const address = server.address() as import('net').AddressInfo;
+    const base = `http://127.0.0.1:${address.port}`;
+
+    try {
+      const res = await fetch(`${base}/ready`);
+      const body = (await res.json()) as { status: string };
+      expect(res.status).toBe(503);
+      expect(body.status).toBe('not_ready');
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      );
+    }
+  });
+
+  it('GET /diagnostics returns config summary', async () => {
+    const { base, stop } = await startTestServer();
+    try {
+      const res = await fetch(`${base}/diagnostics`);
+      const body = (await res.json()) as { config: { entries: unknown[] } };
+      expect(res.status).toBe(200);
+      expect(Array.isArray(body.config.entries)).toBe(true);
+    } finally {
+      await stop();
+    }
+  });
+});

--- a/apps/api/tests/rate-limit.middleware.test.ts
+++ b/apps/api/tests/rate-limit.middleware.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createRateLimiter } from '../src/middlewares/rate-limit.middleware';
+import type { Request, Response, NextFunction } from 'express';
+
+const makeReq = (ip = '127.0.0.1'): Request =>
+  ({ ip, headers: {} } as unknown as Request);
+
+function makeRes() {
+  const state = { status: 200, body: null as unknown };
+  const res = {
+    setHeader: vi.fn(),
+    status: vi.fn((code: number) => { state.status = code; return res; }),
+    json: vi.fn((body: unknown) => { state.body = body; return res; }),
+  } as unknown as Response;
+  return { res, state };
+}
+
+describe('CHORD-026 rate limiting', () => {
+  it('allows requests under the limit', () => {
+    const limiter = createRateLimiter({ windowMs: 60_000, max: 3 });
+    const nextFn = vi.fn() as unknown as NextFunction;
+    const { res } = makeRes();
+    limiter(makeReq(), res, nextFn);
+    expect(nextFn).toHaveBeenCalledOnce();
+  });
+
+  it('blocks requests over the limit with 429', () => {
+    const limiter = createRateLimiter({ windowMs: 60_000, max: 2 });
+    const req = makeReq('10.0.0.1');
+    const nextFn = vi.fn() as unknown as NextFunction;
+
+    // exhaust limit
+    limiter(req, makeRes().res, nextFn);
+    limiter(req, makeRes().res, nextFn);
+
+    // 3rd call should be blocked
+    const { res, state } = makeRes();
+    limiter(req, res, nextFn);
+    expect(state.status).toBe(429);
+  });
+
+  it('sets X-RateLimit headers', () => {
+    const limiter = createRateLimiter({ windowMs: 60_000, max: 10 });
+    const req = makeReq('10.0.0.2');
+    const { res } = makeRes();
+    const nextFn = vi.fn() as unknown as NextFunction;
+
+    limiter(req, res, nextFn);
+
+    expect(res.setHeader).toHaveBeenCalledWith('X-RateLimit-Limit', 10);
+    expect(res.setHeader).toHaveBeenCalledWith('X-RateLimit-Remaining', expect.any(Number));
+    expect(res.setHeader).toHaveBeenCalledWith('X-RateLimit-Reset', expect.any(Number));
+  });
+
+  it('uses custom keyFn', () => {
+    const limiter = createRateLimiter({
+      windowMs: 60_000,
+      max: 1,
+      keyFn: (req) => (req as unknown as { user: string }).user,
+    });
+
+    const req1 = { user: 'alice', ip: '1.1.1.1', headers: {} } as unknown as Request;
+    const req2 = { user: 'bob', ip: '1.1.1.1', headers: {} } as unknown as Request;
+    const nextFn = vi.fn() as unknown as NextFunction;
+
+    limiter(req1, makeRes().res, nextFn); // alice: 1st — allowed
+    limiter(req1, makeRes().res, nextFn); // alice: 2nd — blocked
+    limiter(req2, makeRes().res, nextFn); // bob: 1st — allowed
+
+    expect(nextFn).toHaveBeenCalledTimes(2); // alice(1) + bob(1)
+  });
+});


### PR DESCRIPTION
## Summary

Implements all four backend platform hardening issues for Sprint 1.

Closes #304
Closes #305
Closes #306
Closes #307

---

## Changes

### CHORD-025 — Graceful shutdown & connection draining (`src/shutdown.ts`, `src/app.ts`)
- Registers `SIGTERM` and `SIGINT` handlers on startup
- Stops accepting new connections via `server.close()`
- Disconnects MongoDB after the HTTP server closes
- Forces exit after a 10-second timeout if draining stalls

### CHORD-026 — Rate limiting (`src/middlewares/rate-limit.middleware.ts`)
- In-memory per-IP rate limiter (no Redis dependency)
- **Auth limiter**: 20 requests / 15 min — applied to `/api/v1/auth` and clinic registration
- **Mutation limiter**: 60 requests / min — applied to all `/api/v1` routes
- Sets `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset` headers
- Returns `429` with `Retry-After` when exceeded

### CHORD-027 — Anti-abuse middleware (`src/middlewares/anti-abuse.middleware.ts`)
- **Null-byte guard**: rejects URLs containing `\0` (injection probes)
- **Query-length guard**: rejects query strings > 2 KB
- **Body-size guard**: rejects `POST`/`PUT`/`PATCH` with `Content-Length` > 1 MB
- **Registration abuse guard**: blocks IPs that attempt > 5 registrations/hour

### CHORD-028 — Health endpoints (`src/modules/health/health.controller.ts`)
- `GET /health` — liveness probe; always 200 while process is running
- `GET /ready` — readiness probe; 200 only when MongoDB is reachable, 503 otherwise
- `GET /diagnostics` — full config + dependency detail for ops use

---

## Tests

20 new tests across 4 files — all passing:

| File | Tests |
|---|---|
| `tests/graceful-shutdown.test.ts` | 3 |
| `tests/rate-limit.middleware.test.ts` | 4 |
| `tests/anti-abuse.middleware.test.ts` | 9 |
| `tests/health.controller.test.ts` | 4 |

Pre-existing failures in `subscription.middleware.test.ts` and `app.factory.test.ts` are unrelated to this PR (files unchanged from `main`).