### PR TITLE
feat: CHORD-033/034/035/036 data model rebuild

### DIFF
--- a/apps/api/src/modules/artists/models/artist-profile.model.ts
+++ b/apps/api/src/modules/artists/models/artist-profile.model.ts
@@ -1,0 +1,59 @@
+import { Schema, Types, model, models } from 'mongoose';
+
+export type VerificationStatus = 'unverified' | 'pending' | 'verified' | 'rejected';
+export type PayoutStatus = 'not_ready' | 'ready' | 'suspended';
+
+export interface ArtistProfileDocument {
+  /** Reference to the canonical User document */
+  userId: Types.ObjectId;
+  displayName: string;
+  bio?: string;
+  avatarUrl?: string;
+  genres: string[];
+  /** Public Stellar wallet address for tip payouts */
+  stellarAddress?: string;
+  verificationStatus: VerificationStatus;
+  payoutStatus: PayoutStatus;
+  /** Denormalised follower count — updated by background job */
+  followerCount: number;
+  isActive: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const artistProfileSchema = new Schema<ArtistProfileDocument>(
+  {
+    userId: { type: Schema.Types.ObjectId, ref: 'User', required: true, unique: true, index: true },
+    displayName: { type: String, required: true, trim: true },
+    bio: { type: String, trim: true },
+    avatarUrl: { type: String, trim: true },
+    genres: { type: [String], default: [] },
+    stellarAddress: { type: String, trim: true },
+    verificationStatus: {
+      type: String,
+      enum: ['unverified', 'pending', 'verified', 'rejected'],
+      default: 'unverified',
+      index: true,
+    },
+    payoutStatus: {
+      type: String,
+      enum: ['not_ready', 'ready', 'suspended'],
+      default: 'not_ready',
+      index: true,
+    },
+    followerCount: { type: Number, default: 0, min: 0 },
+    isActive: { type: Boolean, default: true, index: true },
+  },
+  { timestamps: true, versionKey: false },
+);
+
+// Discoverability: genre filter + active flag
+artistProfileSchema.index({ genres: 1, isActive: 1 });
+// Payout readiness lookup
+artistProfileSchema.index({ payoutStatus: 1, verificationStatus: 1 });
+// Full-text search on display name
+artistProfileSchema.index({ displayName: 'text' });
+
+export const ArtistProfileModel =
+  models.ArtistProfile ||
+  model<ArtistProfileDocument>('ArtistProfile', artistProfileSchema);

--- a/apps/api/src/modules/encounters/encounters.controller.ts
+++ b/apps/api/src/modules/encounters/encounters.controller.ts
@@ -1,4 +1,4 @@
-import { Request, Response, Router } from 'express';
+import { Request, RequestHandler, Response, Router } from 'express';
 import { authorize, Roles } from '../../middlewares/rbac.middleware';
 import { validateRequest } from '../../middlewares/validate.middleware';
 import { EncounterModel } from './models/encounter.model';
@@ -72,7 +72,7 @@ router.get(
   '/',
   authorize(CREATE_ROLES),
   validateRequest({ query: encounterListQuerySchema }),
-  async (req: EncounterListRequest, res: Response) => {
+  (async (req: EncounterListRequest, res: Response): Promise<Response> => {
     const clinicId = req.user?.clinicId;
 
     if (!clinicId) {
@@ -99,7 +99,7 @@ router.get(
         toPayload(encounter as Parameters<typeof toPayload>[0]),
       ),
     });
-  },
+  }) as unknown as RequestHandler,
 );
 
 router.post(

--- a/apps/api/src/modules/interactive/models/interactive.model.ts
+++ b/apps/api/src/modules/interactive/models/interactive.model.ts
@@ -1,0 +1,116 @@
+import { Schema, Types, model, models } from 'mongoose';
+
+// ── Moment ─────────────────────────────────────────────────────────────────────
+// A timestamped highlight clipped from a live session.
+// Forward-compatible: created during a session, voteable after it ends.
+
+export type MomentStatus = 'active' | 'archived';
+
+export interface MomentDocument {
+  sessionId: Types.ObjectId;
+  artistId: Types.ObjectId;
+  /** Offset in seconds from session start */
+  offsetSeconds: number;
+  title: string;
+  thumbnailUrl?: string;
+  /** Clip playback URL — may be null until processing completes */
+  clipUrl?: string;
+  status: MomentStatus;
+  /** Denormalised vote tally — updated by Vote writes */
+  voteCount: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const momentSchema = new Schema<MomentDocument>(
+  {
+    sessionId: { type: Schema.Types.ObjectId, ref: 'Session', required: true, index: true },
+    artistId: { type: Schema.Types.ObjectId, ref: 'ArtistProfile', required: true, index: true },
+    offsetSeconds: { type: Number, required: true, min: 0 },
+    title: { type: String, required: true, trim: true },
+    thumbnailUrl: { type: String, trim: true },
+    clipUrl: { type: String, trim: true },
+    status: {
+      type: String,
+      enum: ['active', 'archived'],
+      default: 'active',
+      index: true,
+    },
+    voteCount: { type: Number, default: 0, min: 0 },
+  },
+  { timestamps: true, versionKey: false },
+);
+
+// Top moments per session sorted by votes
+momentSchema.index({ sessionId: 1, voteCount: -1 });
+// Artist's moment library
+momentSchema.index({ artistId: 1, status: 1, createdAt: -1 });
+
+export const MomentModel =
+  models.Moment || model<MomentDocument>('Moment', momentSchema);
+
+// ── Vote ───────────────────────────────────────────────────────────────────────
+// One vote per fan per moment — enforced by unique compound index.
+
+export interface VoteDocument {
+  momentId: Types.ObjectId;
+  fanId: Types.ObjectId;
+  sessionId: Types.ObjectId;
+  createdAt: Date;
+}
+
+const voteSchema = new Schema<VoteDocument>(
+  {
+    momentId: { type: Schema.Types.ObjectId, ref: 'Moment', required: true, index: true },
+    fanId: { type: Schema.Types.ObjectId, ref: 'User', required: true, index: true },
+    sessionId: { type: Schema.Types.ObjectId, ref: 'Session', required: true, index: true },
+  },
+  { timestamps: { createdAt: true, updatedAt: false }, versionKey: false },
+);
+
+// One vote per fan per moment
+voteSchema.index({ momentId: 1, fanId: 1 }, { unique: true });
+// Fan's voting history per session
+voteSchema.index({ fanId: 1, sessionId: 1 });
+
+export const VoteModel =
+  models.Vote || model<VoteDocument>('Vote', voteSchema);
+
+// ── Unlock ─────────────────────────────────────────────────────────────────────
+// Records that a fan has unlocked premium content (e.g. exclusive clip)
+// by meeting a tip threshold or purchasing directly.
+
+export type UnlockType = 'tip_threshold' | 'direct_purchase';
+
+export interface UnlockDocument {
+  fanId: Types.ObjectId;
+  momentId: Types.ObjectId;
+  sessionId: Types.ObjectId;
+  type: UnlockType;
+  /** Reference to the TipTransaction that triggered this unlock, if applicable */
+  transactionId?: Types.ObjectId;
+  createdAt: Date;
+}
+
+const unlockSchema = new Schema<UnlockDocument>(
+  {
+    fanId: { type: Schema.Types.ObjectId, ref: 'User', required: true, index: true },
+    momentId: { type: Schema.Types.ObjectId, ref: 'Moment', required: true, index: true },
+    sessionId: { type: Schema.Types.ObjectId, ref: 'Session', required: true, index: true },
+    type: {
+      type: String,
+      enum: ['tip_threshold', 'direct_purchase'],
+      required: true,
+    },
+    transactionId: { type: Schema.Types.ObjectId, ref: 'TipTransaction' },
+  },
+  { timestamps: { createdAt: true, updatedAt: false }, versionKey: false },
+);
+
+// One unlock per fan per moment
+unlockSchema.index({ fanId: 1, momentId: 1 }, { unique: true });
+// Fan's unlocked content per session
+unlockSchema.index({ fanId: 1, sessionId: 1 });
+
+export const UnlockModel =
+  models.Unlock || model<UnlockDocument>('Unlock', unlockSchema);

--- a/apps/api/src/modules/sessions/models/session.model.ts
+++ b/apps/api/src/modules/sessions/models/session.model.ts
@@ -1,0 +1,56 @@
+import { Schema, Types, model, models } from 'mongoose';
+
+export type SessionStatus = 'draft' | 'live' | 'ended' | 'cancelled';
+
+export interface SessionDocument {
+  artistId: Types.ObjectId;
+  title: string;
+  description?: string;
+  status: SessionStatus;
+  /** Stream key / RTMP identifier — only set when live */
+  streamKey?: string;
+  /** Public playback URL — set when live */
+  playbackUrl?: string;
+  /** Scheduled start time — set for draft sessions */
+  scheduledAt?: Date;
+  startedAt?: Date;
+  endedAt?: Date;
+  /** Running viewer count — updated by socket events */
+  viewerCount: number;
+  /** Cumulative tip total in XLM */
+  totalTipsXlm: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const sessionSchema = new Schema<SessionDocument>(
+  {
+    artistId: { type: Schema.Types.ObjectId, ref: 'ArtistProfile', required: true, index: true },
+    title: { type: String, required: true, trim: true },
+    description: { type: String, trim: true },
+    status: {
+      type: String,
+      enum: ['draft', 'live', 'ended', 'cancelled'],
+      default: 'draft',
+      index: true,
+    },
+    streamKey: { type: String, trim: true },
+    playbackUrl: { type: String, trim: true },
+    scheduledAt: { type: Date },
+    startedAt: { type: Date },
+    endedAt: { type: Date },
+    viewerCount: { type: Number, default: 0, min: 0 },
+    totalTipsXlm: { type: String, default: '0' },
+  },
+  { timestamps: true, versionKey: false },
+);
+
+// Live session discovery: active sessions by artist
+sessionSchema.index({ artistId: 1, status: 1 });
+// Global live feed sorted by recency
+sessionSchema.index({ status: 1, startedAt: -1 });
+// Scheduled sessions upcoming feed
+sessionSchema.index({ status: 1, scheduledAt: 1 });
+
+export const SessionModel =
+  models.Session || model<SessionDocument>('Session', sessionSchema);

--- a/apps/api/src/modules/tips/models/tip.model.ts
+++ b/apps/api/src/modules/tips/models/tip.model.ts
@@ -1,0 +1,103 @@
+import { Schema, Types, model, models } from 'mongoose';
+
+// ── TipIntent ──────────────────────────────────────────────────────────────────
+// Represents the fan's declared intent to tip before the blockchain submission.
+// Created client-side; transitions to a TipTransaction once submitted.
+
+export type TipIntentStatus = 'pending' | 'submitted' | 'expired' | 'cancelled';
+
+export interface TipIntentDocument {
+  fanId: Types.ObjectId;
+  artistId: Types.ObjectId;
+  sessionId: Types.ObjectId;
+  amountXlm: string;
+  /** Idempotency key supplied by the client */
+  idempotencyKey: string;
+  status: TipIntentStatus;
+  /** Set when the intent is promoted to a TipTransaction */
+  transactionId?: Types.ObjectId;
+  expiresAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const tipIntentSchema = new Schema<TipIntentDocument>(
+  {
+    fanId: { type: Schema.Types.ObjectId, ref: 'User', required: true, index: true },
+    artistId: { type: Schema.Types.ObjectId, ref: 'ArtistProfile', required: true, index: true },
+    sessionId: { type: Schema.Types.ObjectId, ref: 'Session', required: true, index: true },
+    amountXlm: { type: String, required: true },
+    idempotencyKey: { type: String, required: true, unique: true, index: true },
+    status: {
+      type: String,
+      enum: ['pending', 'submitted', 'expired', 'cancelled'],
+      default: 'pending',
+      index: true,
+    },
+    transactionId: { type: Schema.Types.ObjectId, ref: 'TipTransaction' },
+    expiresAt: { type: Date, required: true, index: true },
+  },
+  { timestamps: true, versionKey: false },
+);
+
+// Replay-safety: fan + session + idempotency key
+tipIntentSchema.index({ fanId: 1, sessionId: 1, status: 1 });
+// Expiry sweep job
+tipIntentSchema.index({ status: 1, expiresAt: 1 });
+
+export const TipIntentModel =
+  models.TipIntent || model<TipIntentDocument>('TipIntent', tipIntentSchema);
+
+// ── TipTransaction ─────────────────────────────────────────────────────────────
+// Represents the settled on-chain state after Stellar submission.
+
+export type TipTransactionStatus = 'pending' | 'confirmed' | 'failed';
+
+export interface TipTransactionDocument {
+  intentId: Types.ObjectId;
+  fanId: Types.ObjectId;
+  artistId: Types.ObjectId;
+  sessionId: Types.ObjectId;
+  amountXlm: string;
+  /** Stellar transaction hash — set once confirmed */
+  txHash?: string;
+  status: TipTransactionStatus;
+  /** Number of submission attempts */
+  attempts: number;
+  nextRetryAt?: Date | null;
+  confirmedAt?: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const tipTransactionSchema = new Schema<TipTransactionDocument>(
+  {
+    intentId: { type: Schema.Types.ObjectId, ref: 'TipIntent', required: true, unique: true, index: true },
+    fanId: { type: Schema.Types.ObjectId, ref: 'User', required: true, index: true },
+    artistId: { type: Schema.Types.ObjectId, ref: 'ArtistProfile', required: true, index: true },
+    sessionId: { type: Schema.Types.ObjectId, ref: 'Session', required: true, index: true },
+    amountXlm: { type: String, required: true },
+    txHash: { type: String, trim: true },
+    status: {
+      type: String,
+      enum: ['pending', 'confirmed', 'failed'],
+      default: 'pending',
+      index: true,
+    },
+    attempts: { type: Number, default: 0, min: 0 },
+    nextRetryAt: { type: Date, default: null },
+    confirmedAt: { type: Date, default: null },
+  },
+  { timestamps: true, versionKey: false },
+);
+
+// Retry worker: pending transactions due for retry
+tipTransactionSchema.index({ status: 1, nextRetryAt: 1 });
+// Artist earnings history
+tipTransactionSchema.index({ artistId: 1, status: 1, createdAt: -1 });
+// Fan tip history
+tipTransactionSchema.index({ fanId: 1, createdAt: -1 });
+
+export const TipTransactionModel =
+  models.TipTransaction ||
+  model<TipTransactionDocument>('TipTransaction', tipTransactionSchema);

--- a/apps/api/tests/data-models.test.ts
+++ b/apps/api/tests/data-models.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it } from 'vitest';
+import { Schema, Types } from 'mongoose';
+
+// ── CHORD-033: ArtistProfile ───────────────────────────────────────────────────
+describe('ArtistProfile model (CHORD-033)', () => {
+  it('exports ArtistProfileModel with correct collection name', async () => {
+    const { ArtistProfileModel } = await import(
+      '../src/modules/artists/models/artist-profile.model'
+    );
+    expect(ArtistProfileModel.modelName).toBe('ArtistProfile');
+  });
+
+  it('schema has required userId and displayName fields', async () => {
+    const { ArtistProfileModel } = await import(
+      '../src/modules/artists/models/artist-profile.model'
+    );
+    const schema = ArtistProfileModel.schema;
+    expect(schema.path('userId')).toBeDefined();
+    expect(schema.path('displayName')).toBeDefined();
+  });
+
+  it('verificationStatus defaults to unverified', async () => {
+    const { ArtistProfileModel } = await import(
+      '../src/modules/artists/models/artist-profile.model'
+    );
+    const doc = new ArtistProfileModel({
+      userId: new Types.ObjectId(),
+      displayName: 'Test Artist',
+    });
+    expect(doc.verificationStatus).toBe('unverified');
+  });
+
+  it('payoutStatus defaults to not_ready', async () => {
+    const { ArtistProfileModel } = await import(
+      '../src/modules/artists/models/artist-profile.model'
+    );
+    const doc = new ArtistProfileModel({
+      userId: new Types.ObjectId(),
+      displayName: 'Test Artist',
+    });
+    expect(doc.payoutStatus).toBe('not_ready');
+  });
+
+  it('genres defaults to empty array', async () => {
+    const { ArtistProfileModel } = await import(
+      '../src/modules/artists/models/artist-profile.model'
+    );
+    const doc = new ArtistProfileModel({
+      userId: new Types.ObjectId(),
+      displayName: 'Test Artist',
+    });
+    expect(doc.genres).toEqual([]);
+  });
+
+  it('has compound indexes for discoverability and payout', async () => {
+    const { ArtistProfileModel } = await import(
+      '../src/modules/artists/models/artist-profile.model'
+    );
+    const indexes = ArtistProfileModel.schema.indexes();
+    const keys = indexes.map(([key]) => JSON.stringify(key));
+    expect(keys.some((k) => k.includes('genres'))).toBe(true);
+    expect(keys.some((k) => k.includes('payoutStatus'))).toBe(true);
+  });
+});
+
+// ── CHORD-034: Session ─────────────────────────────────────────────────────────
+describe('Session model (CHORD-034)', () => {
+  it('exports SessionModel with correct collection name', async () => {
+    const { SessionModel } = await import(
+      '../src/modules/sessions/models/session.model'
+    );
+    expect(SessionModel.modelName).toBe('Session');
+  });
+
+  it('status defaults to draft', async () => {
+    const { SessionModel } = await import(
+      '../src/modules/sessions/models/session.model'
+    );
+    const doc = new SessionModel({
+      artistId: new Types.ObjectId(),
+      title: 'My First Stream',
+    });
+    expect(doc.status).toBe('draft');
+  });
+
+  it('viewerCount defaults to 0', async () => {
+    const { SessionModel } = await import(
+      '../src/modules/sessions/models/session.model'
+    );
+    const doc = new SessionModel({
+      artistId: new Types.ObjectId(),
+      title: 'My First Stream',
+    });
+    expect(doc.viewerCount).toBe(0);
+  });
+
+  it('totalTipsXlm defaults to "0"', async () => {
+    const { SessionModel } = await import(
+      '../src/modules/sessions/models/session.model'
+    );
+    const doc = new SessionModel({
+      artistId: new Types.ObjectId(),
+      title: 'My First Stream',
+    });
+    expect(doc.totalTipsXlm).toBe('0');
+  });
+
+  it('rejects invalid status values', async () => {
+    const { SessionModel } = await import(
+      '../src/modules/sessions/models/session.model'
+    );
+    const doc = new SessionModel({
+      artistId: new Types.ObjectId(),
+      title: 'Bad Status',
+      status: 'unknown',
+    });
+    const err = doc.validateSync();
+    expect(err?.errors['status']).toBeDefined();
+  });
+
+  it('has compound indexes for live feed and scheduled feed', async () => {
+    const { SessionModel } = await import(
+      '../src/modules/sessions/models/session.model'
+    );
+    const indexes = SessionModel.schema.indexes();
+    const keys = indexes.map(([key]) => JSON.stringify(key));
+    expect(keys.some((k) => k.includes('startedAt'))).toBe(true);
+    expect(keys.some((k) => k.includes('scheduledAt'))).toBe(true);
+  });
+});
+
+// ── CHORD-035: TipIntent + TipTransaction ─────────────────────────────────────
+describe('TipIntent model (CHORD-035)', () => {
+  it('exports TipIntentModel with correct collection name', async () => {
+    const { TipIntentModel } = await import(
+      '../src/modules/tips/models/tip.model'
+    );
+    expect(TipIntentModel.modelName).toBe('TipIntent');
+  });
+
+  it('status defaults to pending', async () => {
+    const { TipIntentModel } = await import(
+      '../src/modules/tips/models/tip.model'
+    );
+    const doc = new TipIntentModel({
+      fanId: new Types.ObjectId(),
+      artistId: new Types.ObjectId(),
+      sessionId: new Types.ObjectId(),
+      amountXlm: '10',
+      idempotencyKey: 'key-001',
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    expect(doc.status).toBe('pending');
+  });
+
+  it('requires idempotencyKey', async () => {
+    const { TipIntentModel } = await import(
+      '../src/modules/tips/models/tip.model'
+    );
+    const doc = new TipIntentModel({
+      fanId: new Types.ObjectId(),
+      artistId: new Types.ObjectId(),
+      sessionId: new Types.ObjectId(),
+      amountXlm: '10',
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const err = doc.validateSync();
+    expect(err?.errors['idempotencyKey']).toBeDefined();
+  });
+});
+
+describe('TipTransaction model (CHORD-035)', () => {
+  it('exports TipTransactionModel with correct collection name', async () => {
+    const { TipTransactionModel } = await import(
+      '../src/modules/tips/models/tip.model'
+    );
+    expect(TipTransactionModel.modelName).toBe('TipTransaction');
+  });
+
+  it('status defaults to pending and attempts to 0', async () => {
+    const { TipTransactionModel } = await import(
+      '../src/modules/tips/models/tip.model'
+    );
+    const doc = new TipTransactionModel({
+      intentId: new Types.ObjectId(),
+      fanId: new Types.ObjectId(),
+      artistId: new Types.ObjectId(),
+      sessionId: new Types.ObjectId(),
+      amountXlm: '10',
+    });
+    expect(doc.status).toBe('pending');
+    expect(doc.attempts).toBe(0);
+  });
+
+  it('has retry worker index on status + nextRetryAt', async () => {
+    const { TipTransactionModel } = await import(
+      '../src/modules/tips/models/tip.model'
+    );
+    const indexes = TipTransactionModel.schema.indexes();
+    const keys = indexes.map(([key]) => JSON.stringify(key));
+    expect(keys.some((k) => k.includes('nextRetryAt'))).toBe(true);
+  });
+});
+
+// ── CHORD-036: Moment, Vote, Unlock ───────────────────────────────────────────
+describe('Moment model (CHORD-036)', () => {
+  it('exports MomentModel with correct collection name', async () => {
+    const { MomentModel } = await import(
+      '../src/modules/interactive/models/interactive.model'
+    );
+    expect(MomentModel.modelName).toBe('Moment');
+  });
+
+  it('status defaults to active and voteCount to 0', async () => {
+    const { MomentModel } = await import(
+      '../src/modules/interactive/models/interactive.model'
+    );
+    const doc = new MomentModel({
+      sessionId: new Types.ObjectId(),
+      artistId: new Types.ObjectId(),
+      offsetSeconds: 120,
+      title: 'Epic Drop',
+    });
+    expect(doc.status).toBe('active');
+    expect(doc.voteCount).toBe(0);
+  });
+});
+
+describe('Vote model (CHORD-036)', () => {
+  it('exports VoteModel with correct collection name', async () => {
+    const { VoteModel } = await import(
+      '../src/modules/interactive/models/interactive.model'
+    );
+    expect(VoteModel.modelName).toBe('Vote');
+  });
+
+  it('has unique compound index on momentId + fanId', async () => {
+    const { VoteModel } = await import(
+      '../src/modules/interactive/models/interactive.model'
+    );
+    const indexes = VoteModel.schema.indexes();
+    const uniqueIdx = indexes.find(
+      ([key, opts]) =>
+        JSON.stringify(key).includes('momentId') &&
+        JSON.stringify(key).includes('fanId') &&
+        (opts as { unique?: boolean }).unique === true,
+    );
+    expect(uniqueIdx).toBeDefined();
+  });
+});
+
+describe('Unlock model (CHORD-036)', () => {
+  it('exports UnlockModel with correct collection name', async () => {
+    const { UnlockModel } = await import(
+      '../src/modules/interactive/models/interactive.model'
+    );
+    expect(UnlockModel.modelName).toBe('Unlock');
+  });
+
+  it('has unique compound index on fanId + momentId', async () => {
+    const { UnlockModel } = await import(
+      '../src/modules/interactive/models/interactive.model'
+    );
+    const indexes = UnlockModel.schema.indexes();
+    const uniqueIdx = indexes.find(
+      ([key, opts]) =>
+        JSON.stringify(key).includes('fanId') &&
+        JSON.stringify(key).includes('momentId') &&
+        (opts as { unique?: boolean }).unique === true,
+    );
+    expect(uniqueIdx).toBeDefined();
+  });
+
+  it('rejects invalid unlock type', async () => {
+    const { UnlockModel } = await import(
+      '../src/modules/interactive/models/interactive.model'
+    );
+    const doc = new UnlockModel({
+      fanId: new Types.ObjectId(),
+      momentId: new Types.ObjectId(),
+      sessionId: new Types.ObjectId(),
+      type: 'free',
+    });
+    const err = doc.validateSync();
+    expect(err?.errors['type']).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Implements all four Data Model Rebuild issues in a single cohesive PR.

Closes #312
Closes #313
Closes #314
Closes #315

---

## CHORD-033 — ArtistProfile schema

**File:** `apps/api/src/modules/artists/models/artist-profile.model.ts`

Models public identity, genres, verification flags, payout readiness, and discoverability:

- `userId` (unique ref → User), `displayName`, `bio`, `avatarUrl`, `genres[]`
- `stellarAddress` for XLM payouts
- `verificationStatus`: `unverified | pending | verified | rejected`
- `payoutStatus`: `not_ready | ready | suspended`
- `followerCount` (denormalised, updated by background job), `isActive`
- Indexes: `genres+isActive` (discoverability), `payoutStatus+verificationStatus` (payout readiness), `displayName` text search

## CHORD-034 — Session schema

**File:** `apps/api/src/modules/sessions/models/session.model.ts`

Captures stream metadata, runtime counters, audience metrics, and archival fields:

- `artistId`, `title`, `description`
- `status`: `draft | live | ended | cancelled`
- `streamKey`, `playbackUrl`, `scheduledAt`, `startedAt`, `endedAt`
- `viewerCount` (runtime counter), `totalTipsXlm` (running total)
- Indexes: `artistId+status`, `status+startedAt` (live feed), `status+scheduledAt` (upcoming feed)

## CHORD-035 — TipIntent + TipTransaction schemas

**File:** `apps/api/src/modules/tips/models/tip.model.ts`

Separates client intent, blockchain submission state, and settlement state for replay safety:

**TipIntent** — fan's declared intent before submission:
- `fanId`, `artistId`, `sessionId`, `amountXlm`, `idempotencyKey` (unique)
- `status`: `pending | submitted | expired | cancelled`, `expiresAt`
- Indexes: `fanId+sessionId+status` (replay safety), `status+expiresAt` (expiry sweep)

**TipTransaction** — settled on-chain state:
- `intentId` (unique), `fanId`, `artistId`, `sessionId`, `amountXlm`, `txHash`
- `status`: `pending | confirmed | failed`, `attempts`, `nextRetryAt`, `confirmedAt`
- Indexes: `status+nextRetryAt` (retry worker), `artistId+status+createdAt` (earnings), `fanId+createdAt` (history)

## CHORD-036 — Moment, Vote, Unlock schemas

**File:** `apps/api/src/modules/interactive/models/interactive.model.ts`

Forward-compatible documents for future interactive features:

**Moment** — timestamped highlight clipped from a session:
- `sessionId`, `artistId`, `offsetSeconds`, `title`, `thumbnailUrl`, `clipUrl`
- `status`: `active | archived`, `voteCount` (denormalised)
- Indexes: `sessionId+voteCount` (top moments), `artistId+status+createdAt`

**Vote** — one vote per fan per moment (enforced by unique index):
- `momentId`, `fanId`, `sessionId`
- Unique index: `momentId+fanId`

**Unlock** — records premium content access:
- `fanId`, `momentId`, `sessionId`, `type`: `tip_threshold | direct_purchase`, `transactionId?`
- Unique index: `fanId+momentId`

---

## Testing

25 tests across all 4 model groups — all passing. TypeScript build clean.

Also fixes a pre-existing `TS2769` overload error in `encounters.controller.ts`.