### PR TITLE
feat(profiles): artist & fan profile foundation (CHORD-057–060)

### DIFF
--- a/apps/api/src/modules/profiles/fan-privacy.service.ts
+++ b/apps/api/src/modules/profiles/fan-privacy.service.ts
@@ -1,0 +1,63 @@
+import mongoose, { Schema, Document } from "mongoose";
+
+// CHORD-059: fan privacy controls for leaderboard display names
+
+export type LeaderboardVisibility = "real_name" | "pseudonym" | "anonymous";
+
+export interface IFanPrivacySettings extends Document {
+  fanId: string;
+  leaderboardVisibility: LeaderboardVisibility;
+  pseudonym: string | null;
+  /** Per-session overrides: sessionId → visibility */
+  sessionOverrides: Map<string, LeaderboardVisibility>;
+  updatedAt: Date;
+}
+
+const FanPrivacySchema = new Schema<IFanPrivacySettings>({
+  fanId:                 { type: String, required: true, unique: true },
+  leaderboardVisibility: { type: String, enum: ["real_name", "pseudonym", "anonymous"], default: "real_name" },
+  pseudonym:             { type: String, default: null, trim: true, maxlength: 32 },
+  sessionOverrides:      { type: Map, of: String, default: {} },
+  updatedAt:             { type: Date, default: Date.now },
+});
+
+export const FanPrivacySettings = mongoose.model<IFanPrivacySettings>("FanPrivacySettings", FanPrivacySchema);
+
+export async function updatePrivacySettings(
+  fanId: string,
+  visibility: LeaderboardVisibility,
+  pseudonym?: string
+): Promise<IFanPrivacySettings> {
+  const doc = await FanPrivacySettings.findOneAndUpdate(
+    { fanId },
+    { leaderboardVisibility: visibility, pseudonym: pseudonym ?? null, updatedAt: new Date() },
+    { upsert: true, new: true }
+  );
+  return doc!;
+}
+
+export async function setSessionOverride(
+  fanId: string,
+  sessionId: string,
+  visibility: LeaderboardVisibility
+): Promise<void> {
+  await FanPrivacySettings.findOneAndUpdate(
+    { fanId },
+    { $set: { [`sessionOverrides.${sessionId}`]: visibility }, updatedAt: new Date() },
+    { upsert: true }
+  );
+}
+
+export async function resolveDisplayName(
+  fanId: string,
+  realName: string,
+  sessionId?: string
+): Promise<string> {
+  const settings = await FanPrivacySettings.findOne({ fanId });
+  const visibility = (sessionId && settings?.sessionOverrides.get(sessionId))
+    || settings?.leaderboardVisibility
+    || "real_name";
+  if (visibility === "anonymous") return "Anonymous";
+  if (visibility === "pseudonym") return settings?.pseudonym ?? "Anonymous";
+  return realName;
+}

--- a/apps/api/src/modules/profiles/moderation.service.ts
+++ b/apps/api/src/modules/profiles/moderation.service.ts
@@ -1,0 +1,52 @@
+import mongoose, { Schema, Document } from "mongoose";
+
+// CHORD-058: profile moderation fields and controls
+
+export type ModerationState = "clear" | "under_review" | "shadow_restricted" | "hidden";
+
+export interface IModerationRecord extends Document {
+  profileId: string;
+  state: ModerationState;
+  reason: string | null;
+  reviewedBy: string | null;
+  updatedAt: Date;
+}
+
+const ModerationRecordSchema = new Schema<IModerationRecord>({
+  profileId:  { type: String, required: true, unique: true },
+  state:      { type: String, enum: ["clear", "under_review", "shadow_restricted", "hidden"], default: "clear" },
+  reason:     { type: String, default: null },
+  reviewedBy: { type: String, default: null },
+  updatedAt:  { type: Date, default: Date.now },
+});
+
+export const ModerationRecord = mongoose.model<IModerationRecord>("ModerationRecord", ModerationRecordSchema);
+
+export async function setModerationState(
+  profileId: string,
+  state: ModerationState,
+  adminId: string,
+  reason?: string
+): Promise<IModerationRecord> {
+  const doc = await ModerationRecord.findOneAndUpdate(
+    { profileId },
+    { state, reason: reason ?? null, reviewedBy: adminId, updatedAt: new Date() },
+    { upsert: true, new: true }
+  );
+  return doc!;
+}
+
+export async function getModerationState(profileId: string): Promise<ModerationState> {
+  const doc = await ModerationRecord.findOne({ profileId });
+  return doc?.state ?? "clear";
+}
+
+/** Returns true when the profile is publicly visible */
+export function isPubliclyVisible(state: ModerationState): boolean {
+  return state === "clear" || state === "under_review";
+}
+
+export async function isProfileVisible(profileId: string): Promise<boolean> {
+  const state = await getModerationState(profileId);
+  return isPubliclyVisible(state);
+}

--- a/apps/api/src/modules/profiles/profile-contracts.test.ts
+++ b/apps/api/src/modules/profiles/profile-contracts.test.ts
@@ -1,0 +1,72 @@
+// CHORD-060: contract tests for profile APIs and slug behavior
+
+import { reserveSlug, isSlugAvailable } from "./slug.service";
+import { attachWallet, markWalletVerified, getWalletMetadata } from "./wallet-metadata.service";
+import { setModerationState, isProfileVisible } from "./moderation.service";
+import { resolveDisplayName, updatePrivacySettings } from "./fan-privacy.service";
+
+// Minimal test harness (no external runner dependency)
+type TestFn = () => Promise<void>;
+const tests: { name: string; fn: TestFn }[] = [];
+const it = (name: string, fn: TestFn) => tests.push({ name, fn });
+
+// --- slug contracts ---
+it("reserveSlug rejects invalid format", async () => {
+  const r = await reserveSlug("a1", "BAD SLUG!");
+  if (r.ok) throw new Error("expected ok=false");
+});
+
+it("reserveSlug accepts valid slug", async () => {
+  const r = await reserveSlug("artist-1", "cool-artist");
+  if (!r.ok) throw new Error(`expected ok=true, got ${r.reason}`);
+});
+
+it("isSlugAvailable returns false after reservation", async () => {
+  await reserveSlug("artist-2", "taken-slug");
+  const available = await isSlugAvailable("taken-slug");
+  if (available) throw new Error("slug should not be available");
+});
+
+// --- wallet metadata contracts ---
+it("attachWallet rejects non-Stellar address", async () => {
+  const r = await attachWallet("artist-1", "not-a-wallet");
+  if (r.ok) throw new Error("expected ok=false");
+});
+
+it("markWalletVerified returns false for unknown artist", async () => {
+  const ok = await markWalletVerified("ghost-artist");
+  if (ok) throw new Error("expected false");
+});
+
+it("getWalletMetadata returns null for unknown artist", async () => {
+  const meta = await getWalletMetadata("nobody");
+  if (meta !== null) throw new Error("expected null");
+});
+
+// --- moderation visibility contracts ---
+it("hidden profile is not publicly visible", async () => {
+  await setModerationState("profile-x", "hidden", "admin-1", "spam");
+  const visible = await isProfileVisible("profile-x");
+  if (visible) throw new Error("hidden profile should not be visible");
+});
+
+it("clear profile is publicly visible", async () => {
+  await setModerationState("profile-y", "clear", "admin-1");
+  const visible = await isProfileVisible("profile-y");
+  if (!visible) throw new Error("clear profile should be visible");
+});
+
+// --- fan privacy contracts ---
+it("anonymous visibility hides real name", async () => {
+  await updatePrivacySettings("fan-1", "anonymous");
+  const name = await resolveDisplayName("fan-1", "Alice");
+  if (name !== "Anonymous") throw new Error(`expected Anonymous, got ${name}`);
+});
+
+it("real_name visibility returns real name", async () => {
+  await updatePrivacySettings("fan-2", "real_name");
+  const name = await resolveDisplayName("fan-2", "Bob");
+  if (name !== "Bob") throw new Error(`expected Bob, got ${name}`);
+});
+
+export { tests };

--- a/apps/api/src/modules/profiles/wallet-metadata.service.ts
+++ b/apps/api/src/modules/profiles/wallet-metadata.service.ts
@@ -1,0 +1,52 @@
+import mongoose, { Schema, Document } from "mongoose";
+
+// CHORD-057: wallet attachment metadata on artist profiles
+
+export interface IWalletMetadata extends Document {
+  artistId: string;
+  walletAddress: string;
+  network: "mainnet" | "testnet";
+  verified: boolean;
+  lastValidatedAt: Date | null;
+  attachedAt: Date;
+}
+
+const WalletMetadataSchema = new Schema<IWalletMetadata>({
+  artistId:        { type: String, required: true, unique: true },
+  walletAddress:   { type: String, required: true, trim: true },
+  network:         { type: String, enum: ["mainnet", "testnet"], default: "testnet" },
+  verified:        { type: Boolean, default: false },
+  lastValidatedAt: { type: Date, default: null },
+  attachedAt:      { type: Date, default: Date.now },
+});
+
+export const WalletMetadata = mongoose.model<IWalletMetadata>("WalletMetadata", WalletMetadataSchema);
+
+const STELLAR_ADDR_RE = /^G[A-Z2-7]{55}$/;
+
+export async function attachWallet(
+  artistId: string,
+  walletAddress: string,
+  network: "mainnet" | "testnet" = "testnet"
+): Promise<{ ok: boolean; reason?: string }> {
+  if (!STELLAR_ADDR_RE.test(walletAddress)) return { ok: false, reason: "invalid_address" };
+
+  await WalletMetadata.findOneAndUpdate(
+    { artistId },
+    { walletAddress, network, verified: false, lastValidatedAt: null, attachedAt: new Date() },
+    { upsert: true, new: true }
+  );
+  return { ok: true };
+}
+
+export async function markWalletVerified(artistId: string): Promise<boolean> {
+  const result = await WalletMetadata.findOneAndUpdate(
+    { artistId },
+    { verified: true, lastValidatedAt: new Date() }
+  );
+  return result !== null;
+}
+
+export async function getWalletMetadata(artistId: string): Promise<IWalletMetadata | null> {
+  return WalletMetadata.findOne({ artistId });
+}


### PR DESCRIPTION
Adds the four profile foundation services for sprint-1.

- **wallet-metadata.service.ts** — attaches a Stellar wallet to an artist profile, tracks verification status and last validated timestamp (CHORD-057)
- **moderation.service.ts** — stores moderation state (clear / under_review / shadow_restricted / hidden) with admin attribution and audit timestamp (CHORD-058)
- **fan-privacy.service.ts** — lets fans choose real name, pseudonym, or anonymous per leaderboard globally or per session (CHORD-059)
- **profile-contracts.test.ts** — contract tests covering slug validation, wallet attachment, moderation visibility, and fan privacy resolution (CHORD-060)

Closes #336
Closes #337
Closes #338
Closes #339