### PR TITLE
feat: mobile auth persistence, design primitives, network state, and deep-link strategy

### DIFF
--- a/apps/mobile/src/auth/persisted-auth.ts
+++ b/apps/mobile/src/auth/persisted-auth.ts
@@ -1,0 +1,27 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const AUTH_TOKEN_KEY = 'auth_token';
+const REFRESH_TOKEN_KEY = 'auth_refresh_token';
+
+export async function saveAuthSession(token: string, refreshToken: string): Promise<void> {
+  await AsyncStorage.multiSet([
+    [AUTH_TOKEN_KEY, token],
+    [REFRESH_TOKEN_KEY, refreshToken],
+  ]);
+}
+
+export async function getAuthSession(): Promise<{ token: string; refreshToken: string } | null> {
+  const results = await AsyncStorage.multiGet([AUTH_TOKEN_KEY, REFRESH_TOKEN_KEY]);
+  const token = results[0][1];
+  const refreshToken = results[1][1];
+
+  if (!token || !refreshToken) {
+    return null;
+  }
+
+  return { token, refreshToken };
+}
+
+export async function clearAuthSession(): Promise<void> {
+  await AsyncStorage.multiRemove([AUTH_TOKEN_KEY, REFRESH_TOKEN_KEY]);
+}

--- a/apps/mobile/src/design/design-primitives.ts
+++ b/apps/mobile/src/design/design-primitives.ts
@@ -1,0 +1,33 @@
+export const COLORS = {
+  primary: '#6C63FF',
+  secondary: '#3ECFCF',
+  background: '#FFFFFF',
+  surface: '#F5F5F5',
+  text: '#1A1A2E',
+  error: '#E53935',
+  success: '#43A047',
+};
+
+export const SPACING = {
+  xs: 4,
+  sm: 8,
+  md: 16,
+  lg: 24,
+  xl: 32,
+  xxl: 48,
+};
+
+export const TYPOGRAPHY = {
+  headingLg: { fontSize: 32, lineHeight: 40 },
+  headingMd: { fontSize: 24, lineHeight: 32 },
+  bodyMd: { fontSize: 16, lineHeight: 24 },
+  bodySm: { fontSize: 14, lineHeight: 20 },
+  caption: { fontSize: 12, lineHeight: 16 },
+};
+
+export const RADIUS = {
+  sm: 4,
+  md: 8,
+  lg: 16,
+  full: 9999,
+};

--- a/apps/mobile/src/hooks/useNetworkState.ts
+++ b/apps/mobile/src/hooks/useNetworkState.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+import NetInfo, { NetInfoState } from '@react-native-community/netinfo';
+
+interface NetworkState {
+  isConnected: boolean;
+  connectionType: string | null;
+  isInternetReachable: boolean | null;
+}
+
+export function useNetworkState(): NetworkState {
+  const [networkState, setNetworkState] = useState<NetworkState>({
+    isConnected: true,
+    connectionType: null,
+    isInternetReachable: null,
+  });
+
+  useEffect(() => {
+    const unsubscribe = NetInfo.addEventListener((state: NetInfoState) => {
+      setNetworkState({
+        isConnected: state.isConnected ?? false,
+        connectionType: state.type,
+        isInternetReachable: state.isInternetReachable,
+      });
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+
+  return networkState;
+}

--- a/docs/mobile-deep-link-strategy.md
+++ b/docs/mobile-deep-link-strategy.md
@@ -1,0 +1,53 @@
+# Mobile Deep-Link Strategy
+
+## URL Scheme
+
+**Custom URL Scheme:** `lumenhealth://`
+
+**Universal Links Domain:** `app.lumenhealth.com`
+
+## Deep Link Routes
+
+| Deep Link URL | Screen / Route | Description |
+|---|---|---|
+| `lumenhealth://artist/:id` | `ArtistProfile` | Opens the profile page for a given artist by ID |
+| `lumenhealth://session/:id` | `SessionDetail` | Opens a specific session by ID |
+| `lumenhealth://auth/callback` | `AuthCallback` | Handles OAuth/SSO authentication callbacks |
+
+## Implementation Notes
+
+### react-navigation Linking Config
+
+Configure the `linking` prop on `NavigationContainer` to map deep link URLs to screens:
+
+```ts
+const linking = {
+  prefixes: ['lumenhealth://', 'https://app.lumenhealth.com'],
+  config: {
+    screens: {
+      ArtistProfile: 'artist/:id',
+      SessionDetail: 'session/:id',
+      AuthCallback: 'auth/callback',
+    },
+  },
+};
+```
+
+Pass `linking` to `NavigationContainer`:
+
+```tsx
+<NavigationContainer linking={linking}>
+  {/* ... */}
+</NavigationContainer>
+```
+
+### Universal Links (iOS) / App Links (Android)
+
+- **iOS:** Add the `applinks:app.lumenhealth.com` entitlement and host an `apple-app-site-association` file at `https://app.lumenhealth.com/.well-known/apple-app-site-association`.
+- **Android:** Add `intent-filter` entries in `AndroidManifest.xml` referencing `app.lumenhealth.com` and host a `assetlinks.json` file at `https://app.lumenhealth.com/.well-known/assetlinks.json`.
+
+## Fallback Behavior
+
+- Any unrecognised deep link route (`lumenhealth://unknown`) navigates the user to the **Home** screen by default.
+- If the app is not installed, Universal Links fall back to the web URL `https://app.lumenhealth.com` in the browser.
+- Authentication callback URLs are validated against an allowlist before processing to prevent open-redirect attacks.


### PR DESCRIPTION
## Summary

This PR adds four new mobile capabilities to LumenHealth:

- **Persisted auth session handling** using AsyncStorage to store and retrieve auth/refresh tokens across app restarts
- **Shared mobile design primitives** (colors, spacing, typography, border radii) aligned with the existing web design tokens
- **Network-state awareness hook** (`useNetworkState`) using NetInfo to expose connectivity status for offline banners and conditional UI
- **Mobile deep-link strategy documentation** covering URL scheme, Universal Links, react-navigation linking config, and fallback behavior

## Closes

closes #352
closes #353
closes #354
closes #355