### PR TITLE
feat: identity sessions – tests, events, UI hook, error normalizer

### DIFF
--- a/apps/api/src/middlewares/error-normalizer.ts
+++ b/apps/api/src/middlewares/error-normalizer.ts
@@ -1,0 +1,63 @@
+import { ErrorRequestHandler, Request, Response, NextFunction } from "express";
+import { ZodError } from "zod";
+
+/** Canonical error envelope returned by every API controller. */
+export interface ApiErrorShape {
+  error: string;
+  message: string;
+  statusCode: number;
+  issues?: { field: string; message: string }[];
+}
+
+/** Typed error that controllers can throw to set status + code explicitly. */
+export class AppError extends Error {
+  constructor(
+    public readonly statusCode: number,
+    public readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "AppError";
+  }
+}
+
+function normalize(err: unknown, res: Response): void {
+  if (err instanceof AppError) {
+    res.status(err.statusCode).json({
+      error: err.code,
+      message: err.message,
+      statusCode: err.statusCode,
+    } satisfies ApiErrorShape);
+    return;
+  }
+
+  if (err instanceof ZodError) {
+    res.status(400).json({
+      error: "ValidationError",
+      message: "Request validation failed",
+      statusCode: 400,
+      issues: err.issues.map((i) => ({
+        field: i.path.join(".") || "root",
+        message: i.message,
+      })),
+    } satisfies ApiErrorShape);
+    return;
+  }
+
+  // Unknown / unhandled – never leak internals
+  res.status(500).json({
+    error: "InternalServerError",
+    message: "An unexpected error occurred",
+    statusCode: 500,
+  } satisfies ApiErrorShape);
+}
+
+/** Express error-handling middleware – mount last in app.ts */
+export const errorNormalizer: ErrorRequestHandler = (
+  err: unknown,
+  _req: Request,
+  res: Response,
+  _next: NextFunction,
+) => {
+  normalize(err, res);
+};

--- a/apps/api/src/modules/auth/__tests__/identity-sessions.test.ts
+++ b/apps/api/src/modules/auth/__tests__/identity-sessions.test.ts
@@ -1,0 +1,61 @@
+import { signAccessToken, signRefreshToken, verifyAccessToken, verifyRefreshToken } from "../token.service";
+
+// Shared fixture – privacy-safe, deterministic
+const fixture = {
+  userId: "user_abc123",
+  role: "doctor" as const,
+  clinicId: "clinic_xyz",
+};
+
+describe("identity & sessions – token contracts", () => {
+  describe("signAccessToken / verifyAccessToken", () => {
+    it("round-trips a valid access token", () => {
+      const token = signAccessToken(fixture);
+      const decoded = verifyAccessToken(token);
+      expect(decoded).toMatchObject({
+        userId: fixture.userId,
+        role: fixture.role,
+        clinicId: fixture.clinicId,
+      });
+    });
+
+    it("rejects a refresh token presented as access token", () => {
+      const refresh = signRefreshToken(fixture);
+      expect(verifyAccessToken(refresh)).toBeNull();
+    });
+
+    it("rejects a tampered access token", () => {
+      const token = signAccessToken(fixture) + "tampered";
+      expect(verifyAccessToken(token)).toBeNull();
+    });
+  });
+
+  describe("signRefreshToken / verifyRefreshToken", () => {
+    it("round-trips a valid refresh token", () => {
+      const token = signRefreshToken(fixture);
+      const decoded = verifyRefreshToken(token);
+      expect(decoded).toMatchObject(fixture);
+    });
+
+    it("rejects an access token presented as refresh token", () => {
+      const access = signAccessToken(fixture);
+      expect(verifyRefreshToken(access)).toBeNull();
+    });
+
+    it("rejects a tampered refresh token", () => {
+      const token = signRefreshToken(fixture) + "x";
+      expect(verifyRefreshToken(token)).toBeNull();
+    });
+  });
+
+  describe("authorization failure cases", () => {
+    it("returns null for empty string", () => {
+      expect(verifyAccessToken("")).toBeNull();
+      expect(verifyRefreshToken("")).toBeNull();
+    });
+
+    it("returns null for completely invalid input", () => {
+      expect(verifyAccessToken("not.a.jwt")).toBeNull();
+    });
+  });
+});

--- a/apps/api/src/modules/auth/session.events.ts
+++ b/apps/api/src/modules/auth/session.events.ts
@@ -1,0 +1,51 @@
+import { EventEmitter } from "events";
+
+export type SessionEventType = "session.created" | "session.refreshed" | "session.revoked";
+
+export interface SessionEventPayload {
+  eventId: string;
+  type: SessionEventType;
+  userId: string;
+  clinicId: string;
+  issuedAt: number;
+  /** Idempotency key – duplicate delivery with same eventId is a no-op */
+  idempotencyKey: string;
+}
+
+const bus = new EventEmitter();
+bus.setMaxListeners(20);
+
+const processed = new Set<string>();
+
+/** Emit a session domain event. Duplicate eventIds are silently dropped. */
+export function emitSessionEvent(payload: SessionEventPayload): void {
+  if (processed.has(payload.idempotencyKey)) return;
+  processed.add(payload.idempotencyKey);
+  bus.emit(payload.type, payload);
+}
+
+/** Register a handler for a session event type. */
+export function onSessionEvent(
+  type: SessionEventType,
+  handler: (payload: SessionEventPayload) => void | Promise<void>,
+): void {
+  bus.on(type, (payload: SessionEventPayload) => {
+    Promise.resolve(handler(payload)).catch((err: unknown) => {
+      console.error(`[session-events] handler error for ${type}:`, err);
+    });
+  });
+}
+
+/** Build a deterministic idempotency key from userId + issuedAt. */
+export function sessionIdempotencyKey(userId: string, issuedAt: number): string {
+  return `${userId}:${issuedAt}`;
+}
+
+// Default handler: log session creation for audit trail
+onSessionEvent("session.created", (p) => {
+  console.info(`[session] created  user=${p.userId} clinic=${p.clinicId} at=${p.issuedAt}`);
+});
+
+onSessionEvent("session.revoked", (p) => {
+  console.info(`[session] revoked  user=${p.userId} key=${p.idempotencyKey}`);
+});

--- a/apps/web/lib/hooks/useSession.ts
+++ b/apps/web/lib/hooks/useSession.ts
@@ -1,0 +1,62 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  loadTokens,
+  clearTokens,
+  decodeAccessTokenUser,
+  isAccessTokenExpired,
+  type AuthUser,
+} from "@/lib/auth-session";
+
+type SessionStatus = "active" | "expired" | "none";
+
+interface SessionState {
+  user: AuthUser | null;
+  status: SessionStatus;
+  /** Revoke the local session and clear stored tokens */
+  revoke: () => void;
+  /** Re-evaluate the stored token without a network call */
+  refresh: () => void;
+}
+
+/**
+ * useSession – lightweight hook for operator-facing session management.
+ * Reads from localStorage, derives status from the JWT exp claim,
+ * and exposes a revoke action for admin/settings workflows.
+ */
+export function useSession(): SessionState {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [status, setStatus] = useState<SessionStatus>("none");
+
+  const evaluate = useCallback(() => {
+    const tokens = loadTokens();
+    if (!tokens) {
+      setUser(null);
+      setStatus("none");
+      return;
+    }
+
+    if (isAccessTokenExpired(tokens.accessToken)) {
+      setUser(null);
+      setStatus("expired");
+      return;
+    }
+
+    const decoded = decodeAccessTokenUser(tokens.accessToken);
+    setUser(decoded);
+    setStatus(decoded ? "active" : "expired");
+  }, []);
+
+  useEffect(() => {
+    evaluate();
+  }, [evaluate]);
+
+  const revoke = useCallback(() => {
+    clearTokens();
+    setUser(null);
+    setStatus("none");
+  }, []);
+
+  return { user, status, revoke, refresh: evaluate };
+}


### PR DESCRIPTION
Closes #413, closes #412, closes #411, closes #178

**#413** – Added token contract tests covering happy paths, tampered tokens, wrong token type, and empty input for the identity/sessions module.

**#412** – Introduced `session.events.ts`: typed domain events (`session.created`, `session.refreshed`, `session.revoked`) emitted from a lightweight in-process bus with idempotency key deduplication to prevent state corruption on duplicate delivery.

**#411** – Added `useSession` React hook that reads stored tokens, derives `active | expired | none` status from the JWT `exp` claim, and exposes `revoke` / `refresh` actions for operator-facing session management workflows.

**#178** – Added `error-normalizer.ts` Express error-handling middleware that normalises `AppError`, `ZodError`, and unknown errors into a consistent `ApiErrorShape` envelope across all controllers.