### PR TITLE
auth: access policies, session metrics & contributor docs

### DIFF
--- a/apps/api/src/modules/auth/access-policy.domain.ts
+++ b/apps/api/src/modules/auth/access-policy.domain.ts
@@ -1,0 +1,44 @@
+// Issue #416 – Access Policies and Auditability: domain model and invariants
+import { Types } from "mongoose";
+
+export type PolicyEffect = "ALLOW" | "DENY";
+export type PolicyStatus = "ACTIVE" | "REVOKED" | "EXPIRED";
+
+export interface AccessPolicy {
+  _id?: Types.ObjectId;
+  clinicId: Types.ObjectId;       // tenancy boundary – never cross-clinic
+  subjectId: Types.ObjectId;      // user the policy applies to
+  resource: string;               // e.g. "encounters", "patients"
+  actions: string[];              // e.g. ["read", "write"]
+  effect: PolicyEffect;
+  status: PolicyStatus;
+  expiresAt?: Date;               // undefined = no expiry
+  createdBy: Types.ObjectId;      // actor provenance
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+// ── Invariants ────────────────────────────────────────────────────────────────
+// 1. A policy MUST belong to exactly one clinic (clinicId required, indexed).
+// 2. DENY always wins over ALLOW when multiple policies match the same subject+resource.
+// 3. An EXPIRED or REVOKED policy MUST NOT grant access; status check is mandatory.
+// 4. createdBy MUST reference a user in the same clinic.
+// 5. actions array MUST be non-empty; empty-action policies are rejected at write time.
+
+export type PolicyTransition = "activate" | "revoke" | "expire";
+
+const ALLOWED_TRANSITIONS: Record<PolicyStatus, PolicyTransition[]> = {
+  ACTIVE:  ["revoke", "expire"],
+  REVOKED: [],
+  EXPIRED: [],
+};
+
+export function canTransition(current: PolicyStatus, next: PolicyTransition): boolean {
+  return ALLOWED_TRANSITIONS[current].includes(next);
+}
+
+export function isEffective(policy: AccessPolicy): boolean {
+  if (policy.status !== "ACTIVE") return false;
+  if (policy.expiresAt && policy.expiresAt <= new Date()) return false;
+  return true;
+}

--- a/apps/api/src/modules/auth/models/access-policy.model.ts
+++ b/apps/api/src/modules/auth/models/access-policy.model.ts
@@ -1,0 +1,36 @@
+// Issue #417 – Access Policies and Auditability: persistence schema and indexes
+import { Schema, Types, model, models } from "mongoose";
+import type { AccessPolicy } from "../access-policy.domain";
+
+const accessPolicySchema = new Schema<AccessPolicy>(
+  {
+    clinicId: { type: Schema.Types.ObjectId, ref: "Clinic", required: true, index: true },
+    subjectId: { type: Schema.Types.ObjectId, ref: "User", required: true, index: true },
+    resource: { type: String, required: true, trim: true },
+    actions: {
+      type: [String],
+      required: true,
+      validate: { validator: (v: string[]) => v.length > 0, message: "actions must not be empty" },
+    },
+    effect: { type: String, enum: ["ALLOW", "DENY"], required: true },
+    status: { type: String, enum: ["ACTIVE", "REVOKED", "EXPIRED"], required: true, default: "ACTIVE" },
+    expiresAt: { type: Date, required: false, default: undefined, index: true },
+    createdBy: { type: Schema.Types.ObjectId, ref: "User", required: true },
+  },
+  { timestamps: true, versionKey: false },
+);
+
+// Primary lookup: all active policies for a subject within a clinic
+accessPolicySchema.index({ clinicId: 1, subjectId: 1, status: 1 });
+
+// Resource-scoped enforcement: find policies by clinic + resource + status
+accessPolicySchema.index({ clinicId: 1, resource: 1, status: 1 });
+
+// TTL-style expiry sweep (background job can query expiresAt < now, status = ACTIVE)
+accessPolicySchema.index({ expiresAt: 1, status: 1 });
+
+// Audit trail: who created policies in a clinic, ordered by creation time
+accessPolicySchema.index({ clinicId: 1, createdBy: 1, createdAt: -1 });
+
+export const AccessPolicyModel =
+  models.AccessPolicy || model<AccessPolicy>("AccessPolicy", accessPolicySchema);

--- a/apps/api/src/modules/auth/session.docs.ts
+++ b/apps/api/src/modules/auth/session.docs.ts
@@ -1,0 +1,27 @@
+// Issue #415 – Identity and Sessions: rollout, migration, and contribution patterns
+// Machine-readable documentation for the identity-and-sessions workstream.
+
+export const SESSION_ROLLOUT_CHECKLIST = [
+  "Set JWT_ACCESS_TOKEN_SECRET and JWT_REFRESH_TOKEN_SECRET in .env before first deploy.",
+  "Access tokens expire in 15 min; refresh tokens in 7 days – adjust via TOKEN_TTL_* env vars if needed.",
+  "No schema migration required: user documents gain no new required fields in this sprint.",
+  "Rotate secrets with a rolling restart; old tokens are invalidated immediately on secret change.",
+  "Enable session.metrics logs in your log aggregator to track login_failure spikes.",
+] as const;
+
+export const SESSION_EXTENSION_PATTERNS = {
+  addOAuthProvider:
+    "Create a new controller in modules/auth, reuse token.service.ts for token issuance, emit session.metrics events.",
+  addMFAStep:
+    "Insert a pre-token middleware that checks a pending_mfa flag on the User document before calling signAccessToken.",
+  revokeAllSessions:
+    "Store a jti blocklist in Redis or a MongoDB collection; validate in the auth middleware before accepting a token.",
+} as const;
+
+export const SESSION_OPEN_FOLLOWUPS = [
+  "Refresh-token rotation (issue each refresh only once, invalidate on reuse).",
+  "Per-device session tracking for mobile clients.",
+  "Idle-timeout enforcement via last_active timestamp on User.",
+] as const;
+
+export type SessionExtensionKey = keyof typeof SESSION_EXTENSION_PATTERNS;

--- a/apps/api/src/modules/auth/session.metrics.ts
+++ b/apps/api/src/modules/auth/session.metrics.ts
@@ -1,0 +1,52 @@
+// Issue #414 – Identity and Sessions: diagnostics and operational metrics
+// Emits structured, PHI-free logs and in-process counters for session events.
+
+type SessionEvent = "login_success" | "login_failure" | "token_refresh" | "logout" | "token_expired";
+
+interface SessionMetric {
+  event: SessionEvent;
+  clinicId: string;
+  userId?: string;
+  role?: string;
+  ts: string;
+  meta?: Record<string, unknown>;
+}
+
+const counters: Record<SessionEvent, number> = {
+  login_success: 0,
+  login_failure: 0,
+  token_refresh: 0,
+  logout: 0,
+  token_expired: 0,
+};
+
+function emit(metric: SessionMetric): void {
+  counters[metric.event]++;
+  // Structured log – no secrets, no PHI
+  console.log(JSON.stringify({ level: "info", source: "session.metrics", ...metric }));
+}
+
+export function recordLogin(clinicId: string, userId: string, role: string): void {
+  emit({ event: "login_success", clinicId, userId, role, ts: new Date().toISOString() });
+}
+
+export function recordLoginFailure(clinicId: string, reason: string): void {
+  emit({ event: "login_failure", clinicId, ts: new Date().toISOString(), meta: { reason } });
+}
+
+export function recordTokenRefresh(clinicId: string, userId: string): void {
+  emit({ event: "token_refresh", clinicId, userId, ts: new Date().toISOString() });
+}
+
+export function recordLogout(clinicId: string, userId: string): void {
+  emit({ event: "logout", clinicId, userId, ts: new Date().toISOString() });
+}
+
+export function recordTokenExpired(clinicId: string): void {
+  emit({ event: "token_expired", clinicId, ts: new Date().toISOString() });
+}
+
+/** Returns a snapshot of all counters – safe to expose on an internal /healthz endpoint. */
+export function getSessionCounters(): Readonly<typeof counters> {
+  return { ...counters };
+}


### PR DESCRIPTION
Closes #414, closes #415, closes #416, closes #417

- **#416** – `access-policy.domain.ts`: defines the `AccessPolicy` aggregate, state transitions (`ACTIVE → REVOKED/EXPIRED`), and invariants (DENY wins, non-empty actions, same-clinic actor).
- **#417** – `access-policy.model.ts`: Mongoose schema with four compound indexes covering enforcement, expiry sweeps, and audit trail queries.
- **#414** – `session.metrics.ts`: PHI-free structured logs and in-process counters for login, refresh, logout, and expiry events; exposes a `getSessionCounters()` snapshot for health endpoints.
- **#415** – `session.docs.ts`: machine-readable rollout checklist, extension patterns (OAuth, MFA, revocation), and open follow-up items for future contributors.