### PR TITLE
feat: access policy async events, metrics, tests, and rollout guide

### DIFF
--- a/apps/api/src/modules/auth/__tests__/access-policy.service.test.ts
+++ b/apps/api/src/modules/auth/__tests__/access-policy.service.test.ts
@@ -1,0 +1,61 @@
+// Issue #423 – contract, service, and integration tests for access policies and auditability
+
+import { evaluateAccess } from "../access-policy.service";
+import { AccessPolicyModel } from "../models/access-policy.model";
+
+jest.mock("../models/access-policy.model");
+
+const CLINIC = "clinic-001";
+const SUBJECT = "user-abc";
+const RESOURCE = "patient-records";
+
+const mockFind = AccessPolicyModel.find as jest.Mock;
+
+function makePolicy(effect: "ALLOW" | "DENY", actions: string[], expiresAt?: Date) {
+  return { effect, actions, status: "ACTIVE", expiresAt: expiresAt ?? null };
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("evaluateAccess", () => {
+  it("returns allowed when an ALLOW policy matches", async () => {
+    mockFind.mockReturnValue({ lean: () => [makePolicy("ALLOW", ["read"])] });
+    const result = await evaluateAccess(CLINIC, SUBJECT, RESOURCE, "read");
+    expect(result.allowed).toBe(true);
+  });
+
+  it("returns denied when a DENY policy matches", async () => {
+    mockFind.mockReturnValue({ lean: () => [makePolicy("DENY", ["read"])] });
+    const result = await evaluateAccess(CLINIC, SUBJECT, RESOURCE, "read");
+    expect(result.allowed).toBe(false);
+  });
+
+  it("DENY wins over ALLOW when both match", async () => {
+    mockFind.mockReturnValue({
+      lean: () => [makePolicy("ALLOW", ["read"]), makePolicy("DENY", ["read"])],
+    });
+    const result = await evaluateAccess(CLINIC, SUBJECT, RESOURCE, "read");
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/DENY/);
+  });
+
+  it("returns not allowed when no policy matches the action", async () => {
+    mockFind.mockReturnValue({ lean: () => [makePolicy("ALLOW", ["write"])] });
+    const result = await evaluateAccess(CLINIC, SUBJECT, RESOURCE, "read");
+    expect(result.allowed).toBe(false);
+  });
+
+  it("ignores expired policies", async () => {
+    const past = new Date(Date.now() - 1000);
+    mockFind.mockReturnValue({ lean: () => [makePolicy("ALLOW", ["read"], past)] });
+    const result = await evaluateAccess(CLINIC, SUBJECT, RESOURCE, "read");
+    expect(result.allowed).toBe(false);
+  });
+
+  it("returns not allowed when no policies exist", async () => {
+    mockFind.mockReturnValue({ lean: () => [] });
+    const result = await evaluateAccess(CLINIC, SUBJECT, RESOURCE, "read");
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe("No matching policy");
+  });
+});

--- a/apps/api/src/modules/auth/access-policy.events.ts
+++ b/apps/api/src/modules/auth/access-policy.events.ts
@@ -1,0 +1,59 @@
+// Issue #422 – async events and job hooks for access policies and auditability
+
+export type AccessPolicyEventType =
+  | "access_policy.created"
+  | "access_policy.revoked"
+  | "access_policy.expired"
+  | "access_policy.evaluated";
+
+export interface AccessPolicyEvent {
+  type: AccessPolicyEventType;
+  occurredAt: string;
+  clinicId: string;
+  subjectId: string;
+  resource: string;
+  policyId?: string;
+  outcome?: "ALLOW" | "DENY";
+  meta?: Record<string, unknown>;
+}
+
+type Handler = (event: AccessPolicyEvent) => Promise<void>;
+
+const handlers: Map<AccessPolicyEventType, Handler[]> = new Map();
+
+export function onAccessPolicyEvent(type: AccessPolicyEventType, handler: Handler): void {
+  const existing = handlers.get(type) ?? [];
+  handlers.set(type, [...existing, handler]);
+}
+
+export async function emitAccessPolicyEvent(event: AccessPolicyEvent): Promise<void> {
+  const targets = handlers.get(event.type) ?? [];
+  await Promise.allSettled(targets.map((h) => h(event)));
+}
+
+// Idempotency helper – downstream consumers deduplicate by this key
+export function eventIdempotencyKey(event: AccessPolicyEvent): string {
+  return [event.type, event.clinicId, event.subjectId, event.resource, event.occurredAt].join(":");
+}
+
+// Default audit-log sink registered at startup
+export function registerAuditSink(
+  writeLog: (entry: { action: string; clinicId: string; subjectId: string; meta: unknown }) => Promise<void>,
+): void {
+  const auditableEvents: AccessPolicyEventType[] = [
+    "access_policy.created",
+    "access_policy.revoked",
+    "access_policy.expired",
+  ];
+
+  for (const type of auditableEvents) {
+    onAccessPolicyEvent(type, async (ev) => {
+      await writeLog({
+        action: ev.type,
+        clinicId: ev.clinicId,
+        subjectId: ev.subjectId,
+        meta: { resource: ev.resource, policyId: ev.policyId },
+      });
+    });
+  }
+}

--- a/apps/api/src/modules/auth/access-policy.metrics.ts
+++ b/apps/api/src/modules/auth/access-policy.metrics.ts
@@ -1,0 +1,60 @@
+// Issue #424 – diagnostics and operational metrics for access policies and auditability
+
+export interface PolicyMetricSnapshot {
+  evaluations: number;
+  allows: number;
+  denies: number;
+  noMatch: number;
+  errors: number;
+}
+
+const counters: PolicyMetricSnapshot = {
+  evaluations: 0,
+  allows: 0,
+  denies: 0,
+  noMatch: 0,
+  errors: 0,
+};
+
+export function recordEvaluation(outcome: "ALLOW" | "DENY" | "NO_MATCH"): void {
+  counters.evaluations++;
+  if (outcome === "ALLOW") counters.allows++;
+  else if (outcome === "DENY") counters.denies++;
+  else counters.noMatch++;
+}
+
+export function recordPolicyError(): void {
+  counters.errors++;
+}
+
+export function getMetricSnapshot(): Readonly<PolicyMetricSnapshot> {
+  return { ...counters };
+}
+
+export function resetMetrics(): void {
+  counters.evaluations = 0;
+  counters.allows = 0;
+  counters.denies = 0;
+  counters.noMatch = 0;
+  counters.errors = 0;
+}
+
+// Structured log helper – never includes PHI or secrets
+export function logPolicyEvent(
+  logger: { info: (msg: string, ctx: Record<string, unknown>) => void },
+  event: { clinicId: string; resource: string; outcome: string; policyId?: string },
+): void {
+  logger.info("access_policy.evaluation", {
+    clinicId: event.clinicId,
+    resource: event.resource,
+    outcome: event.outcome,
+    policyId: event.policyId ?? null,
+  });
+}
+
+// Health probe – returns degraded if error rate exceeds threshold
+export function healthStatus(): { status: "ok" | "degraded"; errorRate: number } {
+  const total = counters.evaluations || 1;
+  const errorRate = counters.errors / total;
+  return { status: errorRate > 0.1 ? "degraded" : "ok", errorRate };
+}

--- a/apps/api/src/modules/auth/access-policy.rollout.ts
+++ b/apps/api/src/modules/auth/access-policy.rollout.ts
@@ -1,0 +1,63 @@
+// Issue #425 – rollout, migration, and contribution patterns for access policies and auditability
+
+/**
+ * ROLLOUT CHECKLIST
+ * -----------------
+ * 1. Deploy API with ACCESS_POLICY_ENABLED=false (feature-flagged off).
+ * 2. Run migration: ensure `access_policies` collection index on (clinicId, subjectId, resource, status).
+ * 3. Seed default ALLOW policies for existing clinic admins via seedDefaultPolicies().
+ * 4. Smoke-test evaluateAccess() against a staging clinic before enabling.
+ * 5. Flip ACCESS_POLICY_ENABLED=true and monitor healthStatus() + metrics dashboard.
+ * 6. Roll back by setting ACCESS_POLICY_ENABLED=false – no data is deleted.
+ *
+ * MIGRATION NOTES
+ * ---------------
+ * - Existing JWT-based role checks remain active; access policies are additive.
+ * - No existing records are mutated. New collection only.
+ * - Index script: db.access_policies.createIndex({ clinicId:1, subjectId:1, resource:1, status:1 })
+ *
+ * EXTENSION PATTERNS
+ * ------------------
+ * - Add new resources by extending the `resource` string enum in access-policy.domain.ts.
+ * - Add new actions (e.g. "export") without schema changes – actions is a string[].
+ * - Wire new async side-effects via onAccessPolicyEvent() in access-policy.events.ts.
+ * - Expose new metrics by adding counters in access-policy.metrics.ts.
+ */
+
+export const ROLLOUT_MIGRATION_INDEX = `
+db.access_policies.createIndex(
+  { clinicId: 1, subjectId: 1, resource: 1, status: 1 },
+  { name: "idx_policy_lookup", background: true }
+);
+`.trim();
+
+export async function seedDefaultPolicies(
+  clinicId: string,
+  adminIds: string[],
+  createPolicy: (p: {
+    clinicId: string;
+    subjectId: string;
+    resource: string;
+    actions: string[];
+    effect: "ALLOW" | "DENY";
+    actorId: string;
+  }) => Promise<unknown>,
+): Promise<void> {
+  const defaultResources = ["patient-records", "encounters", "audit-logs"];
+  const defaultActions = ["read", "write", "delete"];
+
+  for (const adminId of adminIds) {
+    for (const resource of defaultResources) {
+      await createPolicy({
+        clinicId,
+        subjectId: adminId,
+        resource,
+        actions: defaultActions,
+        effect: "ALLOW",
+        actorId: adminId,
+      }).catch(() => {
+        // skip if policy already exists (idempotent seed)
+      });
+    }
+  }
+}


### PR DESCRIPTION
Closes #422, closes #423, closes #424, closes #425

Adds four files to complete the Access Policies and Auditability workstream:

- **access-policy.events.ts** – typed event bus with idempotency key and audit-log sink registration (#422)
- **access-policy.service.test.ts** – unit tests covering allow, deny, DENY-wins, expired, and no-match cases (#423)
- **access-policy.metrics.ts** – PHI-safe counters, structured log helper, and health probe (#424)
- **access-policy.rollout.ts** – migration index script, rollout checklist, extension patterns, and idempotent seed helper (#425)