### PR TITLE
feat(patients): patient registration & search — domain, schema, service, routes

### DIFF
--- a/apps/api/src/modules/patients/patient.domain.ts
+++ b/apps/api/src/modules/patients/patient.domain.ts
@@ -1,0 +1,70 @@
+/**
+ * Patient domain model and invariants.
+ * Defines aggregate boundaries, status transitions, and business rules
+ * for patient registration and search within a clinic tenant.
+ */
+
+export type PatientSex = "M" | "F" | "O";
+
+export type PatientStatus = "active" | "inactive" | "merged" | "deceased";
+
+export interface PatientIdentity {
+  systemId: string;   // LMN-XXXX, immutable after creation
+  clinicId: string;   // tenant boundary — never cross-clinic reads
+}
+
+export interface PatientDemographics {
+  firstName: string;
+  lastName: string;
+  dateOfBirth: Date;
+  sex: PatientSex;
+  contactNumber: string;
+  address: string;
+}
+
+export interface PatientAggregate extends PatientIdentity, PatientDemographics {
+  status: PatientStatus;
+  createdBy: string;  // actor provenance
+  updatedBy: string;
+}
+
+// ---------------------------------------------------------------------------
+// Invariants
+// ---------------------------------------------------------------------------
+
+/** Minimum age in years for a registerable patient. */
+const MIN_AGE_YEARS = 0;
+
+/** Maximum plausible age — guards against data-entry errors. */
+const MAX_AGE_YEARS = 130;
+
+export function assertValidDateOfBirth(dob: Date): void {
+  const now = new Date();
+  const ageMs = now.getTime() - dob.getTime();
+  const ageYears = ageMs / (1000 * 60 * 60 * 24 * 365.25);
+  if (ageYears < MIN_AGE_YEARS || ageYears > MAX_AGE_YEARS) {
+    throw new Error(`Date of birth out of plausible range (0–${MAX_AGE_YEARS} years).`);
+  }
+}
+
+export function assertValidStatus(
+  current: PatientStatus,
+  next: PatientStatus,
+): void {
+  const forbidden: Partial<Record<PatientStatus, PatientStatus[]>> = {
+    merged: ["active", "inactive"],
+    deceased: ["active", "inactive", "merged"],
+  };
+  if (forbidden[current]?.includes(next)) {
+    throw new Error(`Cannot transition patient from "${current}" to "${next}".`);
+  }
+}
+
+/** Normalise a name fragment for fuzzy search indexing. */
+export function normaliseSearchToken(value: string): string {
+  return value
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]/g, "");
+}

--- a/apps/api/src/modules/patients/patient.routes.ts
+++ b/apps/api/src/modules/patients/patient.routes.ts
@@ -1,0 +1,86 @@
+/**
+ * API contracts and route handlers for patient registration and search.
+ * Validates input before business logic runs; returns problem responses on failure.
+ */
+
+import { Request, Response, Router } from "express";
+import { z } from "zod";
+import { notFoundProblem, unauthorizedProblem } from "../../core/problem";
+import { authorize, Roles } from "../../middlewares/rbac.middleware";
+import { getRequestContext } from "../../middlewares/request-context.middleware";
+import { validateRequest } from "../../middlewares/validate.middleware";
+import { registerPatient, findPatients, getPatient } from "./patient.service";
+
+// ---------------------------------------------------------------------------
+// Zod contracts
+// ---------------------------------------------------------------------------
+
+const registerBody = z.object({
+  firstName:     z.string().trim().min(1).max(100),
+  lastName:      z.string().trim().min(1).max(100),
+  dateOfBirth:   z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Expected YYYY-MM-DD"),
+  sex:           z.enum(["M", "F", "O"]),
+  contactNumber: z.string().trim().min(1).max(30),
+  address:       z.string().trim().min(1).max(300),
+});
+
+const searchQuery = z.object({
+  q:     z.string().trim().min(1),
+  limit: z.coerce.number().int().min(1).max(50).optional(),
+});
+
+const idParams = z.object({ id: z.string().trim().min(1) });
+
+type RegisterBody  = z.infer<typeof registerBody>;
+type SearchQuery   = z.infer<typeof searchQuery>;
+type IdParams      = z.infer<typeof idParams>;
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+const router = Router();
+const ALL_ROLES: Roles[] = Object.values(Roles);
+
+router.post(
+  "/",
+  authorize(ALL_ROLES),
+  validateRequest({ body: registerBody }),
+  async (req: Request<Record<string, string>, unknown, RegisterBody>, res: Response) => {
+    const { clinicId, userId } = getRequestContext(req);
+    if (!clinicId) throw unauthorizedProblem();
+
+    const patient = await registerPatient({ ...req.body, clinicId, actorId: userId ?? "system" });
+    return res.status(201).json({ status: "success", data: patient });
+  },
+);
+
+router.get(
+  "/search",
+  authorize(ALL_ROLES),
+  validateRequest({ query: searchQuery }),
+  async (req: Request<Record<string, string>, unknown, unknown, SearchQuery>, res: Response) => {
+    const { clinicId } = getRequestContext(req);
+    if (!clinicId) throw unauthorizedProblem();
+
+    const results = await findPatients({ query: req.query.q, clinicId, limit: req.query.limit });
+    return res.json({ status: "success", data: results });
+  },
+);
+
+router.get(
+  "/:id",
+  authorize(ALL_ROLES),
+  validateRequest({ params: idParams }),
+  async (req: Request<IdParams>, res: Response) => {
+    const { clinicId } = getRequestContext(req);
+    if (!clinicId) throw unauthorizedProblem();
+
+    const patient = await getPatient(req.params.id, clinicId);
+    if (!patient) throw notFoundProblem("Patient not found");
+
+    return res.json({ status: "success", data: patient });
+  },
+);
+
+export const patientRegistrationRoutes = router;

--- a/apps/api/src/modules/patients/patient.schema.ts
+++ b/apps/api/src/modules/patients/patient.schema.ts
@@ -1,0 +1,55 @@
+/**
+ * Persistence schema and index definitions for the Patient aggregate.
+ * Extends the existing PatientModel with audit metadata and tenancy-safe indexes.
+ */
+
+import { Schema, model, models } from "mongoose";
+import { PatientStatus, PatientSex } from "./patient.domain";
+
+export interface PatientRecord {
+  systemId: string;
+  clinicId: string;
+  firstName: string;
+  lastName: string;
+  dateOfBirth: Date;
+  sex: PatientSex;
+  contactNumber: string;
+  address: string;
+  searchToken: string;   // normalised concat for fuzzy lookup
+  status: PatientStatus;
+  createdBy: string;
+  updatedBy: string;
+}
+
+const patientRecordSchema = new Schema<PatientRecord>(
+  {
+    systemId:      { type: String, required: true, unique: true, index: true, trim: true },
+    clinicId:      { type: String, required: true, index: true },
+    firstName:     { type: String, required: true, trim: true },
+    lastName:      { type: String, required: true, trim: true },
+    dateOfBirth:   { type: Date,   required: true },
+    sex:           { type: String, enum: ["M", "F", "O"], required: true },
+    contactNumber: { type: String, required: true, trim: true },
+    address:       { type: String, required: true, trim: true },
+    searchToken:   { type: String, required: true, trim: true, index: true },
+    status:        { type: String, enum: ["active", "inactive", "merged", "deceased"], default: "active" },
+    createdBy:     { type: String, required: true },
+    updatedBy:     { type: String, required: true },
+  },
+  { timestamps: true, versionKey: false },
+);
+
+// Compound index: tenant-scoped name sort (primary list view)
+patientRecordSchema.index({ clinicId: 1, lastName: 1, firstName: 1 });
+
+// Compound index: tenant-scoped status filter (active patient lists)
+patientRecordSchema.index({ clinicId: 1, status: 1 });
+
+// Full-text index: keyword search across name fields and systemId
+patientRecordSchema.index(
+  { firstName: "text", lastName: "text", systemId: "text" },
+  { name: "patient_text_search" },
+);
+
+export const PatientRecordModel =
+  models.PatientRecord || model<PatientRecord>("PatientRecord", patientRecordSchema);

--- a/apps/api/src/modules/patients/patient.service.ts
+++ b/apps/api/src/modules/patients/patient.service.ts
@@ -1,0 +1,113 @@
+/**
+ * Service layer for patient registration and search.
+ * Concentrates business rules, conflict detection, and cross-module
+ * orchestration. Controllers stay thin; all domain logic lives here.
+ */
+
+import { PatientRecordModel } from "./patient.schema";
+import { PatientCounterModel } from "./models/patient-counter.model";
+import { assertValidDateOfBirth, normaliseSearchToken } from "./patient.domain";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface RegisterPatientInput {
+  firstName: string;
+  lastName: string;
+  dateOfBirth: string;   // ISO-8601 string from request body
+  sex: "M" | "F" | "O";
+  contactNumber: string;
+  address: string;
+  clinicId: string;
+  actorId: string;
+}
+
+export interface PatientSearchInput {
+  query: string;
+  clinicId: string;
+  limit?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const buildSystemId = (counter: number) => `LMN-${String(counter).padStart(4, "0")}`;
+
+const toDto = (doc: InstanceType<typeof PatientRecordModel>) => ({
+  id: String(doc._id),
+  systemId: doc.systemId,
+  firstName: doc.firstName,
+  lastName: doc.lastName,
+  dateOfBirth: doc.dateOfBirth.toISOString(),
+  sex: doc.sex,
+  contactNumber: doc.contactNumber,
+  address: doc.address,
+  status: doc.status,
+});
+
+// ---------------------------------------------------------------------------
+// Operations
+// ---------------------------------------------------------------------------
+
+export async function registerPatient(input: RegisterPatientInput) {
+  const dob = new Date(input.dateOfBirth);
+  assertValidDateOfBirth(dob);
+
+  // Conflict check: same name + DOB + clinic
+  const duplicate = await PatientRecordModel.findOne({
+    clinicId: input.clinicId,
+    firstName: new RegExp(`^${input.firstName}$`, "i"),
+    lastName: new RegExp(`^${input.lastName}$`, "i"),
+    dateOfBirth: dob,
+  }).lean();
+
+  if (duplicate) {
+    throw Object.assign(new Error("Patient record already exists."), { code: "DUPLICATE_PATIENT" });
+  }
+
+  const counter = await PatientCounterModel.findByIdAndUpdate(
+    "patient_system_id_counter",
+    { $inc: { value: 1 } },
+    { upsert: true, new: true, setDefaultsOnInsert: true },
+  ).lean();
+
+  const doc = await PatientRecordModel.create({
+    ...input,
+    dateOfBirth: dob,
+    systemId: buildSystemId(counter?.value ?? 1000),
+    searchToken: normaliseSearchToken(`${input.firstName}${input.lastName}`),
+    status: "active",
+    createdBy: input.actorId,
+    updatedBy: input.actorId,
+  });
+
+  return toDto(doc);
+}
+
+export async function findPatients({ query, clinicId, limit = 10 }: PatientSearchInput) {
+  const token = normaliseSearchToken(query);
+  const loose = new RegExp(query.trim().replace(/\s+/g, ".*"), "i");
+
+  const docs = await PatientRecordModel.find({
+    clinicId,
+    status: "active",
+    $or: [
+      { $text: { $search: query } },
+      { firstName: { $regex: loose } },
+      { lastName: { $regex: loose } },
+      { searchToken: { $regex: token } },
+      { systemId: { $regex: loose } },
+    ],
+  })
+    .limit(limit)
+    .lean();
+
+  return (docs as unknown as InstanceType<typeof PatientRecordModel>[]).map(toDto);
+}
+
+export async function getPatient(id: string, clinicId: string) {
+  const doc = await PatientRecordModel.findOne({ _id: id, clinicId }).lean();
+  return doc ? toDto(doc as unknown as InstanceType<typeof PatientRecordModel>) : null;
+}


### PR DESCRIPTION
Implements the full patient registration and search workstream across four layers:

- **patient.domain.ts** — aggregate boundaries, status transitions, and business invariants (closes #426)
- **patient.schema.ts** — MongoDB schema with tenancy-safe compound indexes and full-text search index (closes #427)
- **patient.service.ts** — service layer handling conflict detection, system-ID generation, and fuzzy search (closes #428)
- **patient.routes.ts** — Zod-validated REST handlers for `POST /patients`, `GET /patients/search`, and `GET /patients/:id` (closes #429)

Closes #426, #427, #428, #429