### PR TITLE
Signal Ledger: auth metrics, log schema, and rotation guardrails

### DIFF
--- a/apps/api/src/auth/logger.ts
+++ b/apps/api/src/auth/logger.ts
@@ -10,6 +10,7 @@ interface AuthLogEntry {
   userId?: string;
   clinicId?: string;
   durationMs?: number;
+  requestId?: string;
   meta?: Record<string, unknown>;
 }
 
@@ -21,6 +22,7 @@ function write(level: LogLevel, entry: AuthLogEntry): void {
     ...(entry.clinicId !== undefined && { clinicId: entry.clinicId }),
     timestamp: new Date().toISOString(),
     ...(entry.durationMs !== undefined && { durationMs: entry.durationMs }),
+    ...(entry.requestId !== undefined && { requestId: entry.requestId }),
     meta: entry.meta ?? {},
   });
   console.log(line);

--- a/apps/api/src/auth/metrics.ts
+++ b/apps/api/src/auth/metrics.ts
@@ -1,0 +1,22 @@
+type CounterKey =
+  | "auth_login_success_total"
+  | "auth_login_failure_total"
+  | "auth_account_lockout_total"
+  | "auth_refresh_success_total"
+  | "auth_refresh_failure_total";
+
+const counters: Record<CounterKey, number> = {
+  auth_login_success_total: 0,
+  auth_login_failure_total: 0,
+  auth_account_lockout_total: 0,
+  auth_refresh_success_total: 0,
+  auth_refresh_failure_total: 0,
+};
+
+export function incrementMetric(key: CounterKey): void {
+  counters[key] += 1;
+}
+
+export function getAuthMetricsSnapshot(): Record<CounterKey, number> {
+  return { ...counters };
+}

--- a/apps/api/src/auth/router.ts
+++ b/apps/api/src/auth/router.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import type { LoginRequest, LoginResponse, LogoutResponse, MeResponse, RegisterRequest, RegisterResponse } from "@lumen/types";
 import { authErrorStatus, normalizeAuthError } from "./errors.js";
 import { authLogger } from "./logger.js";
+import { getAuthMetricsSnapshot, incrementMetric } from "./metrics.js";
 import { accessTokenSigner } from "./token-signer.js";
 import { makeSession, sessionStore } from "./session-store.js";
 import { validatePassword } from "./password-policy.js";
@@ -115,8 +116,11 @@ router.post("/verify/complete", (req, res) => {
 });
 
 router.post("/login", (req, res) => {
+  const requestId = req.header("x-request-id") ?? randomUUID();
   if (limited(`login:${req.ip ?? "unknown"}`, 10)) {
     const err = { error: "AUTH_RATE_LIMITED" as const, message: "too many login attempts" };
+    incrementMetric("auth_login_failure_total");
+    incrementMetric("auth_account_lockout_total");
     res.status(429).json(err);
     return;
   }
@@ -125,7 +129,8 @@ router.post("/login", (req, res) => {
   if (!body.email || typeof body.email !== "string" ||
       !body.password || typeof body.password !== "string") {
     const err = { error: "AUTH_MISSING_CREDENTIALS" as const, message: "email and password are required" };
-    authLogger.warn("auth.login.failure", { meta: { reason: err.error } });
+    incrementMetric("auth_login_failure_total");
+    authLogger.warn("auth.login.failure", { requestId, meta: { reason: err.error } });
     res.status(authErrorStatus(err.error)).json(err);
     return;
   }
@@ -151,7 +156,9 @@ router.post("/login", (req, res) => {
   );
   seenRefreshTokens.add(refreshToken);
 
+  incrementMetric("auth_login_success_total");
   authLogger.info("auth.login.success", {
+    requestId,
     userId: payload.session.userId,
     clinicId: payload.session.clinicId,
   });
@@ -160,23 +167,27 @@ router.post("/login", (req, res) => {
 });
 
 router.post("/refresh", (req, res) => {
+  const requestId = req.header("x-request-id") ?? randomUUID();
   if (limited(`refresh:${req.ip ?? "unknown"}`, 20)) {
     const err = { error: "AUTH_RATE_LIMITED" as const, message: "too many refresh attempts" };
+    incrementMetric("auth_refresh_failure_total");
     res.status(429).json(err);
     return;
   }
   const refreshToken = (req.body as { refreshToken?: string }).refreshToken;
   if (!refreshToken) {
     const err = { error: "AUTH_TOKEN_INVALID" as const, message: "refreshToken is required" };
+    incrementMetric("auth_refresh_failure_total");
     res.status(authErrorStatus(err.error)).json(err);
     return;
   }
   const existing = sessionStore.findByRefreshToken(refreshToken);
   if (!existing) {
     if (seenRefreshTokens.has(refreshToken)) {
-      authLogger.warn("auth.token.expired", { meta: { reason: "refresh_reuse_detected" } });
+      authLogger.warn("auth.token.expired", { requestId, meta: { reason: "refresh_reuse_detected" } });
     }
     const err = { error: "AUTH_TOKEN_INVALID" as const, message: "invalid refresh token" };
+    incrementMetric("auth_refresh_failure_total");
     res.status(authErrorStatus(err.error)).json(err);
     return;
   }
@@ -193,8 +204,13 @@ router.post("/refresh", (req, res) => {
       refreshToken: nextRefresh,
     })
   );
-  authLogger.info("auth.token.refreshed", { userId: existing.userId, clinicId: existing.clinicId, meta: { fp: `${req.ip ?? "unknown"}:${req.headers["user-agent"] ?? "na"}` } });
+  incrementMetric("auth_refresh_success_total");
+  authLogger.info("auth.token.refreshed", { requestId, userId: existing.userId, clinicId: existing.clinicId, meta: { fp: `${req.ip ?? "unknown"}:${req.headers["user-agent"] ?? "na"}` } });
   res.json({ ok: true, accessToken: nextAccess, refreshToken: nextRefresh });
+});
+
+router.get("/metrics", (_req, res) => {
+  res.json({ ok: true, metrics: getAuthMetricsSnapshot() });
 });
 
 router.post("/logout", (_req, res) => {

--- a/apps/api/src/modules/auth/__tests__/controller.integration.test.ts
+++ b/apps/api/src/modules/auth/__tests__/controller.integration.test.ts
@@ -152,6 +152,27 @@ describe("POST /api/v1/auth/refresh — basic validation and replay signal", () 
     expect(status).toBe(401);
     expect((body as { error: string }).error).toBe("AUTH_TOKEN_INVALID");
   });
+
+  it("returns 401 for invalid refresh token", async () => {
+    const { status, body } = await request(app, "POST", "/api/v1/auth/refresh", { refreshToken: "bad-token" });
+    expect(status).toBe(401);
+    expect((body as { error: string }).error).toBe("AUTH_TOKEN_INVALID");
+  });
+});
+
+describe("POST /api/v1/auth/login — lockout/rate-limit edge", () => {
+  const app = buildApp();
+
+  it("returns 429 after repeated requests from same source", async () => {
+    let lastStatus = 200;
+    for (let i = 0; i < 11; i += 1) {
+      const { status } = await request(app, "POST", "/api/v1/auth/login", {}, {
+        "x-forwarded-for": "9.9.9.9",
+      });
+      lastStatus = status;
+    }
+    expect(lastStatus).toBe(429);
+  });
 });
 
 describe("POST /api/v1/auth/password-reset/request", () => {

--- a/docs/auth-secret-rotation.md
+++ b/docs/auth-secret-rotation.md
@@ -1,0 +1,28 @@
+# Auth Secret Rotation Procedure
+
+This runbook defines the minimum safe rotation path for auth signing and session secrets.
+
+## Scope
+- JWT signing secret (`JWT_SECRET`)
+- Refresh/session secret material (if externalized)
+- Any auth-related API keys used by auth services
+
+## Rotation Steps
+1. Generate new secrets in the platform secret manager.
+2. Stage deploy with dual-read window:
+- Keep old secret as fallback verifier.
+- Use new secret for fresh signing.
+3. Verify health:
+- `POST /api/v1/auth/login` returns valid session.
+- `POST /api/v1/auth/refresh` rotates tokens without spike in failures.
+- `GET /api/v1/auth/metrics` does not show abnormal `auth_refresh_failure_total`.
+4. Cut over:
+- Remove old verifier after expiry window passes.
+- Force logout of stale sessions if required by policy.
+5. Audit:
+- Capture rotation timestamp, operator, and incident link in ops notes.
+
+## Validation Checklist
+- No secret values are logged.
+- Auth logs include request IDs for traceability.
+- Rollback secret is retained until validation completes.


### PR DESCRIPTION
## Summary
Minimal backend auth observability/security patch for assigned issues.

### What changed
- Added in-memory auth metrics counters and  exposure.
- Added structured  field support to auth logger entries.
- Wired login/refresh failure and success counters in auth routes.
- Added focused integration tests for lockout/rate-limit edge and invalid refresh token behavior.
- Added a concrete auth secret-rotation procedure runbook.

## Closes
- Closes #484
- Closes #485
- Closes #486
- Closes #487
