### PR TITLE
Policy Spine: shared auth permissions and clinic-scoped guard seam

### DIFF
--- a/apps/api/src/auth/policy-catalog.ts
+++ b/apps/api/src/auth/policy-catalog.ts
@@ -1,0 +1,12 @@
+import type { Permission, RolePolicy, UserRole } from "@lumen/types";
+
+const rolePolicies: Record<UserRole, Permission[]> = {
+  owner: ["auth:read", "auth:write", "billing:read", "billing:write", "patient:read", "patient:write"],
+  admin: ["auth:read", "billing:read", "billing:write", "patient:read", "patient:write"],
+  clinician: ["patient:read", "patient:write"],
+  cashier: ["billing:read", "billing:write"],
+};
+
+export function getRolePolicy(role: UserRole): RolePolicy {
+  return { role, permissions: rolePolicies[role] };
+}

--- a/apps/api/src/auth/role-guard.ts
+++ b/apps/api/src/auth/role-guard.ts
@@ -1,0 +1,15 @@
+import type { NextFunction, Request, Response } from "express";
+import { getRolePolicy } from "./policy-catalog.js";
+import type { Permission, UserRole } from "@lumen/types";
+
+export function requirePermission(permission: Permission) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const role = (req.headers["x-role"] as UserRole | undefined) ?? "clinician";
+    const policy = getRolePolicy(role);
+    if (!policy.permissions.includes(permission)) {
+      res.status(403).json({ error: "AUTH_FORBIDDEN", message: "insufficient permission" });
+      return;
+    }
+    next();
+  };
+}

--- a/apps/api/src/auth/router.ts
+++ b/apps/api/src/auth/router.ts
@@ -6,6 +6,7 @@ import { authLogger } from "./logger.js";
 import { accessTokenSigner } from "./token-signer.js";
 import { makeSession, sessionStore } from "./session-store.js";
 import { validatePassword } from "./password-policy.js";
+import { requirePermission } from "./role-guard.js";
 
 // Placeholder router — full implementation in subsequent auth milestones.
 const router = Router();
@@ -207,7 +208,7 @@ router.post("/logout", (_req, res) => {
   res.json(payload);
 });
 
-router.get("/me", (req, res) => {
+router.get("/me", requirePermission("auth:read"), (req, res) => {
   const auth = req.headers.authorization;
   if (!auth?.startsWith("Bearer ")) {
     const err = { error: "AUTH_TOKEN_INVALID" as const, message: "missing bearer token" };

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -5,6 +5,19 @@
 
 export type UserRole = "owner" | "admin" | "clinician" | "cashier";
 
+export type Permission =
+  | "auth:read"
+  | "auth:write"
+  | "billing:read"
+  | "billing:write"
+  | "patient:read"
+  | "patient:write";
+
+export type RolePolicy = {
+  role: UserRole;
+  permissions: Permission[];
+};
+
 // ── Session ──────────────────────────────────────────────────────────────────
 
 export type AuthSession = {


### PR DESCRIPTION
Summary: introduces minimal RBAC foundations for auth policy modeling and route protection.

What changed:
- Added shared role/permission primitives in @lumen/types.
- Added clinic-scoped role policy lookup catalog.
- Added API role-aware guard middleware boundary.
- Applied guard to auth me endpoint as a starter protection seam.

Closes #492
Closes #493
Closes #494
Closes #495