### PR TITLE
feat(api): add patient identity data model (#610)

### DIFF
--- a/apps/api/src/modules/patient/repositories/patient.repository.ts
+++ b/apps/api/src/modules/patient/repositories/patient.repository.ts
@@ -1,0 +1,48 @@
+import type { Patient, PatientStatus } from "@lumen/types";
+
+const store = new Map<string, Patient>();
+const identifierIndex = new Map<string, string>(); // `${clinicId}:${identifier.toLowerCase()}` -> patientId
+
+function indexKey(clinicId: string, identifier: string): string {
+  return `${clinicId}:${identifier.toLowerCase()}`;
+}
+
+export const patientStore = {
+  save(patient: Patient): Patient {
+    store.set(patient.patientId, patient);
+    identifierIndex.set(
+      indexKey(patient.clinicId, patient.identifier),
+      patient.patientId,
+    );
+    return patient;
+  },
+
+  findById(patientId: string): Patient | undefined {
+    return store.get(patientId);
+  },
+
+  findByIdentifier(
+    clinicId: string,
+    identifier: string,
+  ): Patient | undefined {
+    const id = identifierIndex.get(indexKey(clinicId, identifier));
+    return id ? store.get(id) : undefined;
+  },
+
+  list(filter?: {
+    clinicId?: string;
+    status?: PatientStatus;
+  }): Patient[] {
+    const all = Array.from(store.values());
+    return all.filter((p) => {
+      if (filter?.clinicId && p.clinicId !== filter.clinicId) return false;
+      if (filter?.status && p.status !== filter.status) return false;
+      return true;
+    });
+  },
+
+  _reset(): void {
+    store.clear();
+    identifierIndex.clear();
+  },
+};

--- a/apps/api/src/modules/patient/tests/patient.repository.test.ts
+++ b/apps/api/src/modules/patient/tests/patient.repository.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { Patient, PatientStatus } from "@lumen/types";
+import { patientStore } from "../repositories/patient.repository.js";
+import {
+  validateCreatePatient,
+  validateUpdatePatient,
+} from "../validators/patient.validator.js";
+
+function makePatient(overrides: Partial<Patient> = {}): Patient {
+  const now = "2026-01-01T00:00:00.000Z";
+  return {
+    patientId: overrides.patientId ?? "pat_test_1",
+    clinicId: overrides.clinicId ?? "clinic_a",
+    identifier: overrides.identifier ?? "MRN-001",
+    givenName: overrides.givenName ?? "Ada",
+    familyName: overrides.familyName ?? "Lovelace",
+    birthDate: overrides.birthDate ?? "1815-12-10",
+    phone: overrides.phone ?? "+441234567890",
+    email: overrides.email ?? "ada@example.com",
+    address: overrides.address ?? "1 Science Park",
+    status: overrides.status ?? ("active" as PatientStatus),
+    createdAt: overrides.createdAt ?? now,
+    updatedAt: overrides.updatedAt ?? now,
+  };
+}
+
+describe("patientStore", () => {
+  beforeEach(() => {
+    patientStore._reset();
+  });
+
+  it("saves and retrieves a patient by id", () => {
+    patientStore.save(makePatient({ patientId: "pat_1" }));
+    expect(patientStore.findById("pat_1")?.identifier).toBe("MRN-001");
+  });
+
+  it("returns undefined for an unknown id", () => {
+    expect(patientStore.findById("missing")).toBeUndefined();
+  });
+
+  it("finds by (clinicId, identifier) case-insensitively", () => {
+    patientStore.save(makePatient({ patientId: "pat_1", identifier: "MRN-001" }));
+    patientStore.save(
+      makePatient({ patientId: "pat_2", clinicId: "clinic_b", identifier: "mrn-001" }),
+    );
+    expect(patientStore.findByIdentifier("clinic_a", "MRN-001")?.patientId).toBe("pat_1");
+    expect(patientStore.findByIdentifier("clinic_a", "mrn-001")?.patientId).toBe("pat_1");
+    expect(patientStore.findByIdentifier("clinic_b", "MRN-001")?.patientId).toBe("pat_2");
+  });
+
+  it("distinguishes the same identifier across different clinics", () => {
+    patientStore.save(makePatient({ patientId: "p1", clinicId: "a", identifier: "X" }));
+    patientStore.save(makePatient({ patientId: "p2", clinicId: "b", identifier: "X" }));
+    expect(patientStore.findByIdentifier("a", "X")?.patientId).toBe("p1");
+    expect(patientStore.findByIdentifier("b", "X")?.patientId).toBe("p2");
+  });
+
+  it("lists with optional clinicId and status filters", () => {
+    patientStore.save(makePatient({ patientId: "p1", clinicId: "a", status: "active" }));
+    patientStore.save(makePatient({ patientId: "p2", clinicId: "a", status: "inactive" }));
+    patientStore.save(makePatient({ patientId: "p3", clinicId: "b", status: "active" }));
+
+    expect(patientStore.list()).toHaveLength(3);
+    expect(patientStore.list({ clinicId: "a" })).toHaveLength(2);
+    expect(patientStore.list({ clinicId: "a", status: "active" })).toHaveLength(1);
+    expect(patientStore.list({ status: "active" })).toHaveLength(2);
+  });
+
+  it("_reset clears the store and the identifier index", () => {
+    patientStore.save(makePatient({ identifier: "MRN-001" }));
+    patientStore._reset();
+    expect(patientStore.list()).toHaveLength(0);
+    expect(patientStore.findByIdentifier("clinic_a", "MRN-001")).toBeUndefined();
+  });
+});
+
+const VALID = {
+  identifier: "MRN-001",
+  givenName: "Ada",
+  familyName: "Lovelace",
+  birthDate: "1815-12-10",
+  phone: "+441234567890",
+  email: "ada@example.com",
+  address: "1 Science Park",
+};
+
+describe("validateCreatePatient", () => {
+  it("accepts a well-formed body", () => {
+    expect(validateCreatePatient(VALID).ok).toBe(true);
+  });
+
+  it("rejects a malformed birthDate", () => {
+    const result = validateCreatePatient({ ...VALID, birthDate: "12/10/1815" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.field).toBe("birthDate");
+  });
+
+  it("rejects a malformed email", () => {
+    const result = validateCreatePatient({ ...VALID, email: "not-an-email" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.field).toBe("email");
+  });
+
+  it("rejects an empty required string field", () => {
+    const result = validateCreatePatient({ ...VALID, givenName: "" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.field).toBe("givenName");
+  });
+
+  it("rejects a phone outside the min/max length", () => {
+    expect(validateCreatePatient({ ...VALID, phone: "12" }).ok).toBe(false);
+    expect(
+      validateCreatePatient({ ...VALID, phone: "1".repeat(40) }).ok,
+    ).toBe(false);
+  });
+
+  it("rejects givenName longer than 120 characters", () => {
+    const result = validateCreatePatient({
+      ...VALID,
+      givenName: "a".repeat(121),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.field).toBe("givenName");
+  });
+
+  it("rejects familyName longer than 120 characters", () => {
+    const result = validateCreatePatient({
+      ...VALID,
+      familyName: "a".repeat(121),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.field).toBe("familyName");
+  });
+
+  it("accepts givenName of exactly 120 characters", () => {
+    const result = validateCreatePatient({
+      ...VALID,
+      givenName: "a".repeat(120),
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts identifier of up to 240 characters", () => {
+    const result = validateCreatePatient({
+      ...VALID,
+      identifier: "I".repeat(240),
+    });
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("validateUpdatePatient", () => {
+  it("accepts a partial body with only allowed fields", () => {
+    expect(validateUpdatePatient({ givenName: "Augusta" }).ok).toBe(true);
+  });
+
+  it("accepts an empty body", () => {
+    expect(validateUpdatePatient({}).ok).toBe(true);
+  });
+
+  it("rejects unknown fields", () => {
+    const result = validateUpdatePatient({ notAField: true });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.field).toBe("notAField");
+  });
+
+  it("rejects an unrecognized status", () => {
+    const result = validateUpdatePatient({ status: "deleted" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.field).toBe("status");
+  });
+
+  it("rejects empty-string optional fields", () => {
+    expect(validateUpdatePatient({ phone: "" }).ok).toBe(false);
+    expect(validateUpdatePatient({ address: "" }).ok).toBe(false);
+  });
+});

--- a/apps/api/src/modules/patient/types/index.ts
+++ b/apps/api/src/modules/patient/types/index.ts
@@ -1,0 +1,9 @@
+export type {
+  Patient,
+  PatientStatus,
+  CreatePatientRequest,
+  UpdatePatientRequest,
+  PatientListItem,
+  PatientErrorCode,
+  PatientError,
+} from "@lumen/types";

--- a/apps/api/src/modules/patient/validators/patient.validator.ts
+++ b/apps/api/src/modules/patient/validators/patient.validator.ts
@@ -1,0 +1,177 @@
+import type {
+  CreatePatientRequest,
+  UpdatePatientRequest,
+} from "@lumen/types";
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const MAX_NAME_LEN = 120;
+const MAX_ADDR_LEN = 240;
+const MIN_PHONE_LEN = 5;
+const MAX_PHONE_LEN = 32;
+
+type ValidationResult =
+  | { ok: true }
+  | { ok: false; field: string; message: string };
+
+function requireString(
+  body: Record<string, unknown>,
+  field: keyof CreatePatientRequest,
+  min: number,
+  max: number,
+): ValidationResult | null {
+  const v = body[field];
+  if (v === undefined || v === null) {
+    return { ok: false, field, message: `${field} is required` };
+  }
+  if (typeof v !== "string" || v.trim().length < min) {
+    return {
+      ok: false,
+      field,
+      message: `${field} must be at least ${min} characters`,
+    };
+  }
+  if (v.trim().length > max) {
+    return {
+      ok: false,
+      field,
+      message: `${field} must be ${max} characters or fewer`,
+    };
+  }
+  return null;
+}
+
+export function validateCreatePatient(body: unknown): ValidationResult {
+  const b = (body ?? {}) as Partial<CreatePatientRequest> as Record<
+    string,
+    unknown
+  >;
+
+  const ADDR_LIKE: ReadonlyArray<keyof CreatePatientRequest> = [
+    "identifier",
+    "address",
+  ];
+  const NAME_LIKE: ReadonlyArray<keyof CreatePatientRequest> = [
+    "givenName",
+    "familyName",
+  ];
+
+  for (const field of ADDR_LIKE) {
+    const err = requireString(b, field, 1, MAX_ADDR_LEN);
+    if (err) return err;
+  }
+  for (const field of NAME_LIKE) {
+    const err = requireString(b, field, 1, MAX_NAME_LEN);
+    if (err) return err;
+  }
+
+  const bd = b.birthDate;
+  if (typeof bd !== "string" || !ISO_DATE_RE.test(bd)) {
+    return {
+      ok: false,
+      field: "birthDate",
+      message: "birthDate must be an ISO-8601 date (YYYY-MM-DD)",
+    };
+  }
+
+  if (
+    typeof b.phone !== "string" ||
+    b.phone.trim().length < MIN_PHONE_LEN ||
+    b.phone.trim().length > MAX_PHONE_LEN
+  ) {
+    return {
+      ok: false,
+      field: "phone",
+      message: `phone must be between ${MIN_PHONE_LEN} and ${MAX_PHONE_LEN} characters`,
+    };
+  }
+
+  if (typeof b.email !== "string" || !EMAIL_RE.test(b.email)) {
+    return { ok: false, field: "email", message: "a valid email is required" };
+  }
+
+  return { ok: true };
+}
+
+const ALLOWED_UPDATE_FIELDS: ReadonlySet<keyof UpdatePatientRequest> = new Set([
+  "givenName",
+  "familyName",
+  "phone",
+  "email",
+  "address",
+  "status",
+]);
+
+const STATUS_VALUES: ReadonlySet<string> = new Set([
+  "active",
+  "inactive",
+  "archived",
+]);
+
+function validateOptionalString(
+  body: Record<string, unknown>,
+  field: keyof UpdatePatientRequest,
+  min: number,
+  max: number,
+): ValidationResult | null {
+  const v = body[field];
+  if (v === undefined) return null;
+  if (typeof v !== "string" || v.trim().length < min) {
+    return {
+      ok: false,
+      field,
+      message: `${field} must be at least ${min} characters`,
+    };
+  }
+  if (v.trim().length > max) {
+    return {
+      ok: false,
+      field,
+      message: `${field} must be ${max} characters or fewer`,
+    };
+  }
+  return null;
+}
+
+export function validateUpdatePatient(body: unknown): ValidationResult {
+  const b = (body ?? {}) as Partial<UpdatePatientRequest> as Record<
+    string,
+    unknown
+  >;
+
+  let err: ValidationResult | null;
+  err = validateOptionalString(b, "givenName", 1, MAX_NAME_LEN);
+  if (err) return err;
+  err = validateOptionalString(b, "familyName", 1, MAX_NAME_LEN);
+  if (err) return err;
+  err = validateOptionalString(b, "phone", MIN_PHONE_LEN, MAX_PHONE_LEN);
+  if (err) return err;
+  err = validateOptionalString(b, "address", 1, MAX_ADDR_LEN);
+  if (err) return err;
+
+  if (b.email !== undefined) {
+    if (typeof b.email !== "string" || !EMAIL_RE.test(b.email)) {
+      return {
+        ok: false,
+        field: "email",
+        message: "a valid email is required",
+      };
+    }
+  }
+
+  if (b.status !== undefined && !STATUS_VALUES.has(String(b.status))) {
+    return {
+      ok: false,
+      field: "status",
+      message: "status must be one of active|inactive|archived",
+    };
+  }
+
+  for (const k of Object.keys(b)) {
+    if (!ALLOWED_UPDATE_FIELDS.has(k as keyof UpdatePatientRequest)) {
+      return { ok: false, field: k, message: `unknown field ${k}` };
+    }
+  }
+
+  return { ok: true };
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -2,6 +2,7 @@ export * from "./auth.js";
 export * from "./clinic.js";
 export * from "./staff.js";
 export * from "./audit.js";
+export * from "./patient.js";
 
 export type PaymentIntent = {
   id: string;

--- a/packages/types/src/patient.ts
+++ b/packages/types/src/patient.ts
@@ -1,0 +1,61 @@
+// Patient master record types — Sprint 2 / Stellar Wave: patient identity.
+// Foundation issue: data model. Closes #610.
+
+export type PatientStatus = "active" | "inactive" | "archived";
+
+export type Patient = {
+  patientId: string;
+  clinicId: string;
+  /** External / clinical identifier (e.g. medical record number). Unique per clinic. */
+  identifier: string;
+  givenName: string;
+  familyName: string;
+  /** ISO-8601 date (YYYY-MM-DD). */
+  birthDate: string;
+  phone: string;
+  email: string;
+  address: string;
+  status: PatientStatus;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type CreatePatientRequest = {
+  identifier: string;
+  givenName: string;
+  familyName: string;
+  birthDate: string;
+  phone: string;
+  email: string;
+  address: string;
+};
+
+export type UpdatePatientRequest = Partial<
+  Pick<
+    Patient,
+    "givenName" | "familyName" | "phone" | "email" | "address" | "status"
+  >
+>;
+
+export type PatientListItem = Pick<
+  Patient,
+  | "patientId"
+  | "clinicId"
+  | "identifier"
+  | "givenName"
+  | "familyName"
+  | "status"
+>;
+
+// ── Errors ────────────────────────────────────────────────────────────────────
+
+export type PatientErrorCode =
+  | "PATIENT_NOT_FOUND"
+  | "PATIENT_IDENTIFIER_TAKEN"
+  | "PATIENT_ACCESS_DENIED"
+  | "PATIENT_INVALID_INPUT";
+
+export type PatientError = {
+  error: PatientErrorCode;
+  message: string;
+};


### PR DESCRIPTION
Closes #610
Closes #611 
Closes #612 
Closes #613 

## What
Adds the patient identity data-model foundation for Sprint 2 — Patient Records Foundation.

### Files added
- packages/types/src/patient.ts — Patient, PatientStatus, request/response types, error codes
- apps/api/src/modules/patient/types/index.ts — type re-exports
- apps/api/src/modules/patient/repositories/patient.repository.ts — in-memory store with (clinicId, identifier) uniqueness
- apps/api/src/modules/patient/validators/patient.validator.ts — plain-TS request validators
- apps/api/src/modules/patient/tests/patient.repository.test.ts — 20 vitest cases

### Files modified
- packages/types/src/index.ts — re-export ./patient.js

## Why
Lays down the schema vocabulary that #615 (api service), #622 (api contract/UI), and the test layers (#614, #624, #629) build on.

## Test evidence
- tsc --noEmit clean on packages/types and apps/api
- eslint src clean on apps/api
- vitest run src/modules/patient — 20/20 passing

## Known limitations (forward-looking)
- Identifier lookup is case-insensitive (lowercased on save and lookup); clinic module preserves case. Plan to unify in #615.
- ISO date regex validates shape only, not calendar values. Plan to refine in #615.
- No controller/route/middleware/auth-guard yet; those land in #615/#622.