### PR TITLE
feat(api): patient repository extensions (#614)

### DIFF
--- a/apps/api/src/modules/patient/repositories/patient.repository.ts
+++ b/apps/api/src/modules/patient/repositories/patient.repository.ts
@@ -1,0 +1,48 @@
+import type { Patient, PatientStatus } from "@lumen/types";
+
+const store = new Map<string, Patient>();
+const identifierIndex = new Map<string, string>(); // `${clinicId}:${identifier.toLowerCase()}` -> patientId
+
+function indexKey(clinicId: string, identifier: string): string {
+  return `${clinicId}:${identifier.toLowerCase()}`;
+}
+
+export const patientStore = {
+  save(patient: Patient): Patient {
+    store.set(patient.patientId, patient);
+    identifierIndex.set(
+      indexKey(patient.clinicId, patient.identifier),
+      patient.patientId,
+    );
+    return patient;
+  },
+
+  findById(patientId: string): Patient | undefined {
+    return store.get(patientId);
+  },
+
+  findByIdentifier(
+    clinicId: string,
+    identifier: string,
+  ): Patient | undefined {
+    const id = identifierIndex.get(indexKey(clinicId, identifier));
+    return id ? store.get(id) : undefined;
+  },
+
+  list(filter?: {
+    clinicId?: string;
+    status?: PatientStatus;
+  }): Patient[] {
+    const all = Array.from(store.values());
+    return all.filter((p) => {
+      if (filter?.clinicId && p.clinicId !== filter.clinicId) return false;
+      if (filter?.status && p.status !== filter.status) return false;
+      return true;
+    });
+  },
+
+  _reset(): void {
+    store.clear();
+    identifierIndex.clear();
+  },
+};

--- a/apps/api/src/modules/patient/repositories/patient.repository.ts
+++ b/apps/api/src/modules/patient/repositories/patient.repository.ts
@@ -1,4 +1,10 @@
-import type { Patient, PatientStatus } from "@lumen/types";
+import type {
+  Patient,
+  PatientStatus,
+  PatientListItem,
+  PatientListPage,
+  PatientErrorCode,
+} from "@lumen/types";
 
 const store = new Map<string, Patient>();
 const identifierIndex = new Map<string, string>(); // `${clinicId}:${identifier.toLowerCase()}` -> patientId
@@ -39,6 +45,119 @@ export const patientStore = {
       if (filter?.status && p.status !== filter.status) return false;
       return true;
     });
+  },
+
+  /**
+   * Case-insensitive partial search across `givenName` and `familyName`,
+   * scoped to a single `clinicId`. Returns the sanitized `PatientListItem`
+   * shape (no phone/email/address/birthDate). Capped at 50 results per
+   * query.
+   */
+  findByClinicAndName(
+    clinicId: string,
+    query: string,
+    limit: number = 50,
+  ): PatientListItem[] {
+    if (typeof query !== "string") return [];
+    const q = query.trim().toLowerCase();
+    if (q.length === 0) return [];
+    const cap = Math.min(Math.max(limit, 1), 50);
+    const out: PatientListItem[] = [];
+    for (const p of store.values()) {
+      if (p.clinicId !== clinicId) continue;
+      const given = p.givenName.toLowerCase();
+      const family = p.familyName.toLowerCase();
+      if (given.includes(q) || family.includes(q)) {
+        out.push({
+          patientId: p.patientId,
+          clinicId: p.clinicId,
+          identifier: p.identifier,
+          givenName: p.givenName,
+          familyName: p.familyName,
+          status: p.status,
+        });
+        if (out.length >= cap) break;
+      }
+    }
+    return out;
+  },
+
+  /**
+   * Paginated list of patients within a clinic, with simple offset/limit
+   * pagination. Hard caps: `limit` 1..50 (default 25), `offset` ≥ 0.
+   */
+  listPaginated(
+    clinicId: string,
+    opts: { limit?: number; offset?: number } = {},
+  ): PatientListPage {
+    const limit = Math.min(Math.max(opts.limit ?? 25, 1), 50);
+    const offset = Math.max(opts.offset ?? 0, 0);
+    const all = Array.from(store.values()).filter(
+      (p) => p.clinicId === clinicId,
+    );
+    const slice = all.slice(offset, offset + limit);
+    return {
+      items: slice.map((p) => ({
+        patientId: p.patientId,
+        clinicId: p.clinicId,
+        identifier: p.identifier,
+        givenName: p.givenName,
+        familyName: p.familyName,
+        status: p.status,
+      })),
+      total: all.length,
+      limit,
+      offset,
+    };
+  },
+
+  /**
+   * Strict save: write only when the (clinicId, identifier) pair is unused
+   * by any *other* patient. Re-saving the same patient with the same
+   * identifier is allowed (idempotent update). Differs from `save` which
+   * silently overwrites the index.
+   */
+  saveStrict(
+    patient: Patient,
+  ):
+    | { ok: true; patient: Patient }
+    | { ok: false; error: PatientErrorCode; message: string } {
+    const existingId = identifierIndex.get(
+      indexKey(patient.clinicId, patient.identifier),
+    );
+    if (existingId && existingId !== patient.patientId) {
+      return {
+        ok: false,
+        error: "PATIENT_IDENTIFIER_TAKEN",
+        message:
+          "this medical record number is already in use in this clinic",
+      };
+    }
+    store.set(patient.patientId, patient);
+    identifierIndex.set(
+      indexKey(patient.clinicId, patient.identifier),
+      patient.patientId,
+    );
+    return { ok: true, patient };
+  },
+
+  /**
+   * Mark an existing patient as archived. Sets `status='archived'`, stamps
+   * `archivedAt` with the current ISO timestamp, and bumps `updatedAt`.
+   * Returns null when the patient does not exist.
+   */
+  archiveById(patientId: string): Patient | null {
+    const p = store.get(patientId);
+    if (!p) return null;
+    const now = new Date().toISOString();
+    const archived: Patient = {
+      ...p,
+      status: "archived",
+      archivedAt: now,
+      updatedAt: now,
+    };
+    store.set(patientId, archived);
+    return archived;
   },
 
   _reset(): void {

--- a/apps/api/src/modules/patient/tests/patient.repository.test.ts
+++ b/apps/api/src/modules/patient/tests/patient.repository.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { Patient, PatientStatus } from "@lumen/types";
+import { patientStore } from "../repositories/patient.repository.js";
+import {
+  validateCreatePatient,
+  validateUpdatePatient,
+} from "../validators/patient.validator.js";
+
+function makePatient(overrides: Partial<Patient> = {}): Patient {
+  const now = "2026-01-01T00:00:00.000Z";
+  return {
+    patientId: overrides.patientId ?? "pat_test_1",
+    clinicId: overrides.clinicId ?? "clinic_a",
+    identifier: overrides.identifier ?? "MRN-001",
+    givenName: overrides.givenName ?? "Ada",
+    familyName: overrides.familyName ?? "Lovelace",
+    birthDate: overrides.birthDate ?? "1815-12-10",
+    phone: overrides.phone ?? "+441234567890",
+    email: overrides.email ?? "ada@example.com",
+    address: overrides.address ?? "1 Science Park",
+    status: overrides.status ?? ("active" as PatientStatus),
+    createdAt: overrides.createdAt ?? now,
+    updatedAt: overrides.updatedAt ?? now,
+  };
+}
+
+describe("patientStore", () => {
+  beforeEach(() => {
+    patientStore._reset();
+  });
+
+  it("saves and retrieves a patient by id", () => {
+    patientStore.save(makePatient({ patientId: "pat_1" }));
+    expect(patientStore.findById("pat_1")?.identifier).toBe("MRN-001");
+  });
+
+  it("returns undefined for an unknown id", () => {
+    expect(patientStore.findById("missing")).toBeUndefined();
+  });
+
+  it("finds by (clinicId, identifier) case-insensitively", () => {
+    patientStore.save(makePatient({ patientId: "pat_1", identifier: "MRN-001" }));
+    patientStore.save(
+      makePatient({ patientId: "pat_2", clinicId: "clinic_b", identifier: "mrn-001" }),
+    );
+    expect(patientStore.findByIdentifier("clinic_a", "MRN-001")?.patientId).toBe("pat_1");
+    expect(patientStore.findByIdentifier("clinic_a", "mrn-001")?.patientId).toBe("pat_1");
+    expect(patientStore.findByIdentifier("clinic_b", "MRN-001")?.patientId).toBe("pat_2");
+  });
+
+  it("distinguishes the same identifier across different clinics", () => {
+    patientStore.save(makePatient({ patientId: "p1", clinicId: "a", identifier: "X" }));
+    patientStore.save(makePatient({ patientId: "p2", clinicId: "b", identifier: "X" }));
+    expect(patientStore.findByIdentifier("a", "X")?.patientId).toBe("p1");
+    expect(patientStore.findByIdentifier("b", "X")?.patientId).toBe("p2");
+  });
+
+  it("lists with optional clinicId and status filters", () => {
+    patientStore.save(makePatient({ patientId: "p1", clinicId: "a", status: "active" }));
+    patientStore.save(makePatient({ patientId: "p2", clinicId: "a", status: "inactive" }));
+    patientStore.save(makePatient({ patientId: "p3", clinicId: "b", status: "active" }));
+
+    expect(patientStore.list()).toHaveLength(3);
+    expect(patientStore.list({ clinicId: "a" })).toHaveLength(2);
+    expect(patientStore.list({ clinicId: "a", status: "active" })).toHaveLength(1);
+    expect(patientStore.list({ status: "active" })).toHaveLength(2);
+  });
+
+  it("_reset clears the store and the identifier index", () => {
+    patientStore.save(makePatient({ identifier: "MRN-001" }));
+    patientStore._reset();
+    expect(patientStore.list()).toHaveLength(0);
+    expect(patientStore.findByIdentifier("clinic_a", "MRN-001")).toBeUndefined();
+  });
+});
+
+const VALID = {
+  identifier: "MRN-001",
+  givenName: "Ada",
+  familyName: "Lovelace",
+  birthDate: "1815-12-10",
+  phone: "+441234567890",
+  email: "ada@example.com",
+  address: "1 Science Park",
+};
+
+describe("validateCreatePatient", () => {
+  it("accepts a well-formed body", () => {
+    expect(validateCreatePatient(VALID).ok).toBe(true);
+  });
+
+  it("rejects a malformed birthDate", () => {
+    const result = validateCreatePatient({ ...VALID, birthDate: "12/10/1815" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.field).toBe("birthDate");
+  });
+
+  it("rejects a malformed email", () => {
+    const result = validateCreatePatient({ ...VALID, email: "not-an-email" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.field).toBe("email");
+  });
+
+  it("rejects an empty required string field", () => {
+    const result = validateCreatePatient({ ...VALID, givenName: "" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.field).toBe("givenName");
+  });
+
+  it("rejects a phone outside the min/max length", () => {
+    expect(validateCreatePatient({ ...VALID, phone: "12" }).ok).toBe(false);
+    expect(
+      validateCreatePatient({ ...VALID, phone: "1".repeat(40) }).ok,
+    ).toBe(false);
+  });
+
+  it("rejects givenName longer than 120 characters", () => {
+    const result = validateCreatePatient({
+      ...VALID,
+      givenName: "a".repeat(121),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.field).toBe("givenName");
+  });
+
+  it("rejects familyName longer than 120 characters", () => {
+    const result = validateCreatePatient({
+      ...VALID,
+      familyName: "a".repeat(121),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.field).toBe("familyName");
+  });
+
+  it("accepts givenName of exactly 120 characters", () => {
+    const result = validateCreatePatient({
+      ...VALID,
+      givenName: "a".repeat(120),
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts identifier of up to 240 characters", () => {
+    const result = validateCreatePatient({
+      ...VALID,
+      identifier: "I".repeat(240),
+    });
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("validateUpdatePatient", () => {
+  it("accepts a partial body with only allowed fields", () => {
+    expect(validateUpdatePatient({ givenName: "Augusta" }).ok).toBe(true);
+  });
+
+  it("accepts an empty body", () => {
+    expect(validateUpdatePatient({}).ok).toBe(true);
+  });
+
+  it("rejects unknown fields", () => {
+    const result = validateUpdatePatient({ notAField: true });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.field).toBe("notAField");
+  });
+
+  it("rejects an unrecognized status", () => {
+    const result = validateUpdatePatient({ status: "deleted" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.field).toBe("status");
+  });
+
+  it("rejects empty-string optional fields", () => {
+    expect(validateUpdatePatient({ phone: "" }).ok).toBe(false);
+    expect(validateUpdatePatient({ address: "" }).ok).toBe(false);
+  });
+});

--- a/apps/api/src/modules/patient/tests/patient.repository.test.ts
+++ b/apps/api/src/modules/patient/tests/patient.repository.test.ts
@@ -175,3 +175,314 @@ describe("validateUpdatePatient", () => {
     expect(validateUpdatePatient({ address: "" }).ok).toBe(false);
   });
 });
+
+describe("findByClinicAndName", () => {
+  beforeEach(() => {
+    patientStore._reset();
+  });
+
+  it("returns partial matches scoped to clinicId", () => {
+    patientStore.save(
+      makePatient({
+        patientId: "p1",
+        clinicId: "a",
+        givenName: "Ada",
+        familyName: "Lovelace",
+      }),
+    );
+    patientStore.save(
+      makePatient({
+        patientId: "p2",
+        clinicId: "a",
+        givenName: "Alan",
+        familyName: "Turing",
+      }),
+    );
+    patientStore.save(
+      makePatient({
+        patientId: "p3",
+        clinicId: "b",
+        givenName: "Ada",
+        familyName: "Byron",
+      }),
+    );
+
+    expect(
+      patientStore.findByClinicAndName("a", "ada").map((p) => p.patientId),
+    ).toEqual(["p1"]);
+    expect(
+      patientStore.findByClinicAndName("b", "ada").map((p) => p.patientId),
+    ).toEqual(["p3"]);
+  });
+
+  it("is case-insensitive across given and family names", () => {
+    patientStore.save(
+      makePatient({
+        patientId: "p1",
+        clinicId: "clinic_a",
+        givenName: "Ada",
+        familyName: "Lovelace",
+      }),
+    );
+    expect(
+      patientStore
+        .findByClinicAndName("clinic_a", "ADA")
+        .map((p) => p.patientId),
+    ).toEqual(["p1"]);
+    expect(
+      patientStore
+        .findByClinicAndName("clinic_a", "ada")
+        .map((p) => p.patientId),
+    ).toEqual(["p1"]);
+    expect(
+      patientStore
+        .findByClinicAndName("clinic_a", "lovelace")
+        .map((p) => p.patientId),
+    ).toEqual(["p1"]);
+  });
+
+  it("matches partial names by substring", () => {
+    patientStore.save(
+      makePatient({
+        patientId: "p1",
+        clinicId: "clinic_a",
+        givenName: "Augusta",
+        familyName: "Byron",
+      }),
+    );
+    patientStore.save(
+      makePatient({
+        patientId: "p2",
+        clinicId: "clinic_a",
+        givenName: "Algernon",
+        familyName: "Blackwood",
+      }),
+    );
+    expect(
+      patientStore
+        .findByClinicAndName("clinic_a", "al")
+        .map((p) => p.patientId),
+    ).toEqual(["p2"]);
+    expect(
+      patientStore
+        .findByClinicAndName("clinic_a", "au")
+        .map((p) => p.patientId),
+    ).toEqual(["p1"]);
+  });
+
+  it("returns empty for empty or whitespace queries", () => {
+    patientStore.save(makePatient({}));
+    expect(
+      patientStore.findByClinicAndName("clinic_a", ""),
+    ).toEqual([]);
+    expect(
+      patientStore.findByClinicAndName("clinic_a", "   "),
+    ).toEqual([]);
+  });
+
+  it("caps results at the limit", () => {
+    for (let i = 0; i < 60; i++) {
+      patientStore.save(
+        makePatient({
+          patientId: `p${i}`,
+          identifier: `mrn-${i}`,
+          givenName: "Same",
+          familyName: "Name",
+        }),
+      );
+    }
+    expect(
+      patientStore.findByClinicAndName("clinic_a", "same").length,
+    ).toBe(50);
+    expect(
+      patientStore.findByClinicAndName("clinic_a", "same", 5).length,
+    ).toBe(5);
+  });
+});
+
+describe("listPaginated", () => {
+  beforeEach(() => {
+    patientStore._reset();
+  });
+
+  it("paginates and reports total", () => {
+    for (let i = 0; i < 30; i++) {
+      patientStore.save(
+        makePatient({ patientId: `p${i}`, identifier: `mrn-${i}` }),
+      );
+    }
+    const page1 = patientStore.listPaginated("clinic_a", {
+      limit: 10,
+      offset: 0,
+    });
+    expect(page1.items.length).toBe(10);
+    expect(page1.total).toBe(30);
+    expect(page1.limit).toBe(10);
+
+    const page2 = patientStore.listPaginated("clinic_a", {
+      limit: 10,
+      offset: 25,
+    });
+    expect(page2.items.length).toBe(5);
+  });
+
+  it("clamps limit between 1 and 50 and offset ≥ 0", () => {
+    for (let i = 0; i < 60; i++) {
+      patientStore.save(
+        makePatient({ patientId: `p${i}`, identifier: `mrn-${i}` }),
+      );
+    }
+    expect(patientStore.listPaginated("clinic_a", { limit: 0 }).limit).toBe(1);
+    expect(
+      patientStore.listPaginated("clinic_a", { limit: 100 }).limit,
+    ).toBe(50);
+    expect(
+      patientStore.listPaginated("clinic_a", { offset: -5 }).offset,
+    ).toBe(0);
+  });
+
+  it("scopes to clinicId before paginating", () => {
+    patientStore.save(
+      makePatient({ patientId: "p1", clinicId: "a", identifier: "mrn-1" }),
+    );
+    patientStore.save(
+      makePatient({ patientId: "p2", clinicId: "b", identifier: "mrn-2" }),
+    );
+    expect(
+      patientStore.listPaginated("a", { limit: 10 }).total,
+    ).toBe(1);
+    expect(
+      patientStore.listPaginated("b", { limit: 10 }).total,
+    ).toBe(1);
+  });
+});
+
+describe("saveStrict", () => {
+  beforeEach(() => {
+    patientStore._reset();
+  });
+
+  it("returns ok when the (clinicId, identifier) pair is unused", () => {
+    const result = patientStore.saveStrict(makePatient({ patientId: "p1" }));
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.patient.patientId).toBe("p1");
+  });
+
+  it("returns ok when re-saving the same patient with same identifier", () => {
+    patientStore.saveStrict(makePatient({ patientId: "p1" }));
+    const result = patientStore.saveStrict(
+      makePatient({ patientId: "p1" }),
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects when a different patient claims the same identifier in the same clinic", () => {
+    patientStore.saveStrict(
+      makePatient({ patientId: "p1", identifier: "MRN-1" }),
+    );
+    const result = patientStore.saveStrict(
+      makePatient({ patientId: "p2", identifier: "MRN-1" }),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBe("PATIENT_IDENTIFIER_TAKEN");
+  });
+
+  it("allows the same identifier across different clinics", () => {
+    patientStore.saveStrict(
+      makePatient({ patientId: "p1", clinicId: "a", identifier: "X" }),
+    );
+    const result = patientStore.saveStrict(
+      makePatient({ patientId: "p2", clinicId: "b", identifier: "X" }),
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it("returns PATIENT_IDENTIFIER_TAKEN with a non-empty message on rejection", () => {
+    patientStore.saveStrict(
+      makePatient({ patientId: "p1", identifier: "MRN-1" }),
+    );
+    const result = patientStore.saveStrict(
+      makePatient({ patientId: "p2", identifier: "MRN-1" }),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("PATIENT_IDENTIFIER_TAKEN");
+      expect(typeof result.message).toBe("string");
+      expect(result.message.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+it("saveStrict preserves the identifier index when rejecting a duplicate", () => {
+  patientStore.saveStrict(
+    makePatient({ patientId: "p1", identifier: "MRN-1" }),
+  );
+  patientStore.saveStrict(
+    makePatient({ patientId: "p2", identifier: "MRN-1" }),
+  );
+  expect(
+    patientStore.findByIdentifier("clinic_a", "MRN-1")?.patientId,
+  ).toBe("p1");
+});
+
+it("archiveById preserves the identifier index", () => {
+  patientStore.save(makePatient({ patientId: "p1", identifier: "MRN-1" }));
+  patientStore.archiveById("p1");
+  expect(
+    patientStore.findByIdentifier("clinic_a", "MRN-1")?.patientId,
+  ).toBe("p1");
+  expect(patientStore.findById("p1")?.status).toBe("archived");
+});
+
+it("listPaginated returns results in stable insertion order", () => {
+  patientStore.save(makePatient({ patientId: "p1", identifier: "mrn-1" }));
+  patientStore.save(makePatient({ patientId: "p2", identifier: "mrn-2" }));
+  patientStore.save(makePatient({ patientId: "p3", identifier: "mrn-3" }));
+  const page = patientStore.listPaginated("clinic_a", {
+    limit: 10,
+    offset: 0,
+  });
+  expect(page.items.map((x) => x.patientId)).toEqual(["p1", "p2", "p3"]);
+});
+
+it("findByClinicAndName returns only the sanitized PatientListItem shape", () => {
+  patientStore._reset();
+  patientStore.save(makePatient({ patientId: "p1" }));
+  const result = patientStore.findByClinicAndName("clinic_a", "ada");
+  expect(result).toHaveLength(1);
+  const item = result[0];
+  expect(item.patientId).toBe("p1");
+  // Structural absence of disallowed PII fields. PatientListItem should only
+  // expose patientId, clinicId, identifier, givenName, familyName, status.
+  const allowedKeys = [
+    "patientId",
+    "clinicId",
+    "identifier",
+    "givenName",
+    "familyName",
+    "status",
+  ];
+  const itemKeys = Object.keys(item);
+  expect(itemKeys.sort()).toEqual(allowedKeys.sort());
+});
+
+describe("archiveById", () => {
+  beforeEach(() => {
+    patientStore._reset();
+  });
+
+  it("returns null for an unknown id", () => {
+    expect(patientStore.archiveById("missing")).toBeNull();
+  });
+
+  it("sets status='archived' and stamps archivedAt", () => {
+    patientStore.save(
+      makePatient({ patientId: "p1", status: "active" }),
+    );
+    const archived = patientStore.archiveById("p1");
+    expect(archived).not.toBeNull();
+    expect(archived!.status).toBe("archived");
+    expect(typeof archived!.archivedAt).toBe("string");
+    expect(archived!.archivedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+});

--- a/apps/api/src/modules/patient/types/index.ts
+++ b/apps/api/src/modules/patient/types/index.ts
@@ -4,6 +4,7 @@ export type {
   CreatePatientRequest,
   UpdatePatientRequest,
   PatientListItem,
+  PatientListPage,
   PatientErrorCode,
   PatientError,
 } from "@lumen/types";

--- a/apps/api/src/modules/patient/types/index.ts
+++ b/apps/api/src/modules/patient/types/index.ts
@@ -1,0 +1,9 @@
+export type {
+  Patient,
+  PatientStatus,
+  CreatePatientRequest,
+  UpdatePatientRequest,
+  PatientListItem,
+  PatientErrorCode,
+  PatientError,
+} from "@lumen/types";

--- a/apps/api/src/modules/patient/validators/patient.validator.ts
+++ b/apps/api/src/modules/patient/validators/patient.validator.ts
@@ -1,0 +1,177 @@
+import type {
+  CreatePatientRequest,
+  UpdatePatientRequest,
+} from "@lumen/types";
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const MAX_NAME_LEN = 120;
+const MAX_ADDR_LEN = 240;
+const MIN_PHONE_LEN = 5;
+const MAX_PHONE_LEN = 32;
+
+type ValidationResult =
+  | { ok: true }
+  | { ok: false; field: string; message: string };
+
+function requireString(
+  body: Record<string, unknown>,
+  field: keyof CreatePatientRequest,
+  min: number,
+  max: number,
+): ValidationResult | null {
+  const v = body[field];
+  if (v === undefined || v === null) {
+    return { ok: false, field, message: `${field} is required` };
+  }
+  if (typeof v !== "string" || v.trim().length < min) {
+    return {
+      ok: false,
+      field,
+      message: `${field} must be at least ${min} characters`,
+    };
+  }
+  if (v.trim().length > max) {
+    return {
+      ok: false,
+      field,
+      message: `${field} must be ${max} characters or fewer`,
+    };
+  }
+  return null;
+}
+
+export function validateCreatePatient(body: unknown): ValidationResult {
+  const b = (body ?? {}) as Partial<CreatePatientRequest> as Record<
+    string,
+    unknown
+  >;
+
+  const ADDR_LIKE: ReadonlyArray<keyof CreatePatientRequest> = [
+    "identifier",
+    "address",
+  ];
+  const NAME_LIKE: ReadonlyArray<keyof CreatePatientRequest> = [
+    "givenName",
+    "familyName",
+  ];
+
+  for (const field of ADDR_LIKE) {
+    const err = requireString(b, field, 1, MAX_ADDR_LEN);
+    if (err) return err;
+  }
+  for (const field of NAME_LIKE) {
+    const err = requireString(b, field, 1, MAX_NAME_LEN);
+    if (err) return err;
+  }
+
+  const bd = b.birthDate;
+  if (typeof bd !== "string" || !ISO_DATE_RE.test(bd)) {
+    return {
+      ok: false,
+      field: "birthDate",
+      message: "birthDate must be an ISO-8601 date (YYYY-MM-DD)",
+    };
+  }
+
+  if (
+    typeof b.phone !== "string" ||
+    b.phone.trim().length < MIN_PHONE_LEN ||
+    b.phone.trim().length > MAX_PHONE_LEN
+  ) {
+    return {
+      ok: false,
+      field: "phone",
+      message: `phone must be between ${MIN_PHONE_LEN} and ${MAX_PHONE_LEN} characters`,
+    };
+  }
+
+  if (typeof b.email !== "string" || !EMAIL_RE.test(b.email)) {
+    return { ok: false, field: "email", message: "a valid email is required" };
+  }
+
+  return { ok: true };
+}
+
+const ALLOWED_UPDATE_FIELDS: ReadonlySet<keyof UpdatePatientRequest> = new Set([
+  "givenName",
+  "familyName",
+  "phone",
+  "email",
+  "address",
+  "status",
+]);
+
+const STATUS_VALUES: ReadonlySet<string> = new Set([
+  "active",
+  "inactive",
+  "archived",
+]);
+
+function validateOptionalString(
+  body: Record<string, unknown>,
+  field: keyof UpdatePatientRequest,
+  min: number,
+  max: number,
+): ValidationResult | null {
+  const v = body[field];
+  if (v === undefined) return null;
+  if (typeof v !== "string" || v.trim().length < min) {
+    return {
+      ok: false,
+      field,
+      message: `${field} must be at least ${min} characters`,
+    };
+  }
+  if (v.trim().length > max) {
+    return {
+      ok: false,
+      field,
+      message: `${field} must be ${max} characters or fewer`,
+    };
+  }
+  return null;
+}
+
+export function validateUpdatePatient(body: unknown): ValidationResult {
+  const b = (body ?? {}) as Partial<UpdatePatientRequest> as Record<
+    string,
+    unknown
+  >;
+
+  let err: ValidationResult | null;
+  err = validateOptionalString(b, "givenName", 1, MAX_NAME_LEN);
+  if (err) return err;
+  err = validateOptionalString(b, "familyName", 1, MAX_NAME_LEN);
+  if (err) return err;
+  err = validateOptionalString(b, "phone", MIN_PHONE_LEN, MAX_PHONE_LEN);
+  if (err) return err;
+  err = validateOptionalString(b, "address", 1, MAX_ADDR_LEN);
+  if (err) return err;
+
+  if (b.email !== undefined) {
+    if (typeof b.email !== "string" || !EMAIL_RE.test(b.email)) {
+      return {
+        ok: false,
+        field: "email",
+        message: "a valid email is required",
+      };
+    }
+  }
+
+  if (b.status !== undefined && !STATUS_VALUES.has(String(b.status))) {
+    return {
+      ok: false,
+      field: "status",
+      message: "status must be one of active|inactive|archived",
+    };
+  }
+
+  for (const k of Object.keys(b)) {
+    if (!ALLOWED_UPDATE_FIELDS.has(k as keyof UpdatePatientRequest)) {
+      return { ok: false, field: k, message: `unknown field ${k}` };
+    }
+  }
+
+  return { ok: true };
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -2,6 +2,7 @@ export * from "./auth.js";
 export * from "./clinic.js";
 export * from "./staff.js";
 export * from "./audit.js";
+export * from "./patient.js";
 
 export type PaymentIntent = {
   id: string;

--- a/packages/types/src/patient.ts
+++ b/packages/types/src/patient.ts
@@ -18,6 +18,8 @@ export type Patient = {
   status: PatientStatus;
   createdAt: string;
   updatedAt: string;
+  /** ISO-8601 timestamp; set automatically when status transitions to 'archived'. */
+  archivedAt?: string;
 };
 
 export type CreatePatientRequest = {
@@ -46,6 +48,14 @@ export type PatientListItem = Pick<
   | "familyName"
   | "status"
 >;
+
+/** A page of patients returned by paginated list endpoints. */
+export type PatientListPage = {
+  items: PatientListItem[];
+  total: number;
+  limit: number;
+  offset: number;
+};
 
 // ── Errors ────────────────────────────────────────────────────────────────────
 

--- a/packages/types/src/patient.ts
+++ b/packages/types/src/patient.ts
@@ -1,0 +1,61 @@
+// Patient master record types — Sprint 2 / Stellar Wave: patient identity.
+// Foundation issue: data model. Closes #610.
+
+export type PatientStatus = "active" | "inactive" | "archived";
+
+export type Patient = {
+  patientId: string;
+  clinicId: string;
+  /** External / clinical identifier (e.g. medical record number). Unique per clinic. */
+  identifier: string;
+  givenName: string;
+  familyName: string;
+  /** ISO-8601 date (YYYY-MM-DD). */
+  birthDate: string;
+  phone: string;
+  email: string;
+  address: string;
+  status: PatientStatus;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type CreatePatientRequest = {
+  identifier: string;
+  givenName: string;
+  familyName: string;
+  birthDate: string;
+  phone: string;
+  email: string;
+  address: string;
+};
+
+export type UpdatePatientRequest = Partial<
+  Pick<
+    Patient,
+    "givenName" | "familyName" | "phone" | "email" | "address" | "status"
+  >
+>;
+
+export type PatientListItem = Pick<
+  Patient,
+  | "patientId"
+  | "clinicId"
+  | "identifier"
+  | "givenName"
+  | "familyName"
+  | "status"
+>;
+
+// ── Errors ────────────────────────────────────────────────────────────────────
+
+export type PatientErrorCode =
+  | "PATIENT_NOT_FOUND"
+  | "PATIENT_IDENTIFIER_TAKEN"
+  | "PATIENT_ACCESS_DENIED"
+  | "PATIENT_INVALID_INPUT";
+
+export type PatientError = {
+  error: PatientErrorCode;
+  message: string;
+};


### PR DESCRIPTION
Closes #614
Closes #615 
Closes #616 
Closes #617 

n\n## Summary\nData-model extensions on top of PR #610.\n\n### Repository additions (apps/api/src/modules/patient/repositories/patient.repository.ts)\n- findByClinicAndName: clinic-scoped partial (case-insensitive) name search returning sanitized PatientListItem. Capped at 50.\n- listPaginated: offset/limit pagination returning PatientListPage with redacted list items. Limit clamped 1..50 default 25.\n- saveStrict: write-collision detection on (clinicId, identifier) returning { ok: false; error: PatientErrorCode; message: string } compatible with package-level PatientError.\n- archiveById: sets status=archived, stamps archivedAt, preserves identifier index.\n\n### Type changes (packages/types/src/patient.ts)\n- Patient.archivedAt?: string.\n- PatientListPage type added.\n\n### Test coverage\nEach new method has dedicated tests; index invariants verified post-archive/saveStrict; shape integrity verified for sanitized list returns.\n\n## Stack note\nFirst of four Stellar Wave Sprint PRs (data-model; subsequent #618 service, #622 API, #626 UI stack on this).\n\n## Test plan\napps/api typecheck rc=0; eslint rc=0; vitest 217 tests pass.