### PR TITLE
feat(api): patient HTTP API boundary (#622)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -3,6 +3,7 @@ import { authRouter } from "./modules/auth/routes/index.js";
 import { invitationRouter } from "./modules/staff/routes/index.js";
 import { staffRouter } from "./modules/staff/routes/staff.routes.js";
 import { clinicRouter } from "./modules/clinic/routes/index.js";
+import { patientRouter } from "./modules/patient/routes/index.js";
 
 const app = express();
 
@@ -16,5 +17,6 @@ app.use("/api/v1/auth", authRouter);
 app.use("/api/v1/staff/invitations", invitationRouter);
 app.use("/api/v1/staff", staffRouter);
 app.use("/api/v1/clinics", clinicRouter);
+app.use("/api/v1/patients", patientRouter);
 
 export { app };

--- a/apps/api/src/modules/patient/controllers/patient.controller.ts
+++ b/apps/api/src/modules/patient/controllers/patient.controller.ts
@@ -1,0 +1,159 @@
+import type { Request, Response } from "express";
+import type {
+  CreatePatientRequest,
+  UpdatePatientRequest,
+} from "@lumen/types";
+import {
+  validateCreatePatient,
+  validateUpdatePatient,
+} from "../validators/patient.validator.js";
+import {
+  createPatient,
+  getPatient,
+  listPatients,
+  updatePatient,
+  archivePatient,
+} from "../services/patient.service.js";
+
+/**
+ * POST /api/v1/patients — create a patient.
+ *
+ * Permission: `patient:write` (owner, admin, clinician). Body shape is
+ * validated upstream of the controller via `validateCreatePatient`;
+ * identifier-uniqueness is enforced at the service layer. Successful
+ * creation returns 201 with the new patient. A duplicate identifier
+ * surfaces as 409 with the package-level `PatientError` envelope.
+ */
+export function create(req: Request, res: Response): void {
+  const validation = validateCreatePatient(req.body);
+  if (!validation.ok) {
+    res.status(400).json({
+      error: "PATIENT_INVALID_INPUT",
+      message: validation.message,
+      field: validation.field,
+    });
+    return;
+  }
+
+  const result = createPatient(
+    req.body as CreatePatientRequest,
+    req.auth!.clinicId,
+  );
+  if ("error" in result) {
+    res.status(409).json(result);
+    return;
+  }
+  res.status(201).json({ patient: result });
+}
+
+/**
+ * GET /api/v1/patients — list patients in the caller's clinic.
+ *
+ * Permission: `patient:read`. Returns the sanitized `PatientListPage`
+ * shape (no PII). Limit/offset query params are parsed via
+ * `parseNonNegativeInt` and forwarded to the service (which clamps to
+ * 1..50 internally).
+ */
+export function list(req: Request, res: Response): void {
+  const limit = parseNonNegativeInt(req.query.limit);
+  const offset = parseNonNegativeInt(req.query.offset);
+  const opts: { limit?: number; offset?: number } = {};
+  if (limit !== undefined) opts.limit = limit;
+  if (offset !== undefined) opts.offset = offset;
+
+  const page = listPatients(req.auth!.clinicId, opts);
+  res.json(page);
+}
+
+/**
+ * GET /api/v1/patients/:patientId — read a patient.
+ *
+ * Permission: `patient:read`. Clinic-isolation is enforced at the service
+ * layer (callerClinicId match); cross-clinic access surfaces as 404 to
+ * avoid existence enumeration.
+ */
+export function get(req: Request, res: Response): void {
+  const patient = getPatient(
+    String(req.params.patientId),
+    req.auth!.clinicId,
+  );
+  if (!patient) {
+    res.status(404).json({
+      error: "PATIENT_NOT_FOUND",
+      message: "patient not found",
+    });
+    return;
+  }
+  res.json({ patient });
+}
+
+/**
+ * PATCH /api/v1/patients/:patientId — update a patient.
+ *
+ * Permission: `patient:write`. Body shape validated upstream; identifier
+ * is not patchable via `UpdatePatientRequest`.
+ */
+export function update(req: Request, res: Response): void {
+  const validation = validateUpdatePatient(req.body);
+  if (!validation.ok) {
+    res.status(400).json({
+      error: "PATIENT_INVALID_INPUT",
+      message: validation.message,
+      field: validation.field,
+    });
+    return;
+  }
+
+  const patient = updatePatient(
+    String(req.params.patientId),
+    req.auth!.clinicId,
+    req.body as UpdatePatientRequest,
+  );
+  if (!patient) {
+    res.status(404).json({
+      error: "PATIENT_NOT_FOUND",
+      message: "patient not found",
+    });
+    return;
+  }
+  res.json({ patient });
+}
+
+/**
+ * DELETE /api/v1/patients/:patientId — archive a patient (soft delete).
+ *
+ * Permission: `patient:write` (any role with patient:write can call this
+ * route; the inline role-check below restricts the action to owner/admin
+ * only). Archiving sets `status='archived'` and stamps `archivedAt`; the
+ * record is not hard-deleted.
+ */
+export function archive(req: Request, res: Response): void {
+  const role = req.auth!.role;
+  if (role !== "owner" && role !== "admin") {
+    res.status(403).json({
+      error: "AUTH_FORBIDDEN",
+      message: "only owner or admin may archive a patient",
+    });
+    return;
+  }
+
+  const patient = archivePatient(
+    String(req.params.patientId),
+    req.auth!.clinicId,
+  );
+  if (!patient) {
+    res.status(404).json({
+      error: "PATIENT_NOT_FOUND",
+      message: "patient not found",
+    });
+    return;
+  }
+  res.status(200).json({ patient });
+}
+
+function parseNonNegativeInt(value: unknown): number | undefined {
+  if (typeof value !== "string") return undefined;
+  const n = Number(value);
+  if (!Number.isFinite(n) || n < 0) return undefined;
+  return n;
+}

--- a/apps/api/src/modules/patient/repositories/patient.repository.ts
+++ b/apps/api/src/modules/patient/repositories/patient.repository.ts
@@ -1,0 +1,48 @@
+import type { Patient, PatientStatus } from "@lumen/types";
+
+const store = new Map<string, Patient>();
+const identifierIndex = new Map<string, string>(); // `${clinicId}:${identifier.toLowerCase()}` -> patientId
+
+function indexKey(clinicId: string, identifier: string): string {
+  return `${clinicId}:${identifier.toLowerCase()}`;
+}
+
+export const patientStore = {
+  save(patient: Patient): Patient {
+    store.set(patient.patientId, patient);
+    identifierIndex.set(
+      indexKey(patient.clinicId, patient.identifier),
+      patient.patientId,
+    );
+    return patient;
+  },
+
+  findById(patientId: string): Patient | undefined {
+    return store.get(patientId);
+  },
+
+  findByIdentifier(
+    clinicId: string,
+    identifier: string,
+  ): Patient | undefined {
+    const id = identifierIndex.get(indexKey(clinicId, identifier));
+    return id ? store.get(id) : undefined;
+  },
+
+  list(filter?: {
+    clinicId?: string;
+    status?: PatientStatus;
+  }): Patient[] {
+    const all = Array.from(store.values());
+    return all.filter((p) => {
+      if (filter?.clinicId && p.clinicId !== filter.clinicId) return false;
+      if (filter?.status && p.status !== filter.status) return false;
+      return true;
+    });
+  },
+
+  _reset(): void {
+    store.clear();
+    identifierIndex.clear();
+  },
+};

--- a/apps/api/src/modules/patient/repositories/patient.repository.ts
+++ b/apps/api/src/modules/patient/repositories/patient.repository.ts
@@ -1,4 +1,10 @@
-import type { Patient, PatientStatus } from "@lumen/types";
+import type {
+  Patient,
+  PatientStatus,
+  PatientListItem,
+  PatientListPage,
+  PatientErrorCode,
+} from "@lumen/types";
 
 const store = new Map<string, Patient>();
 const identifierIndex = new Map<string, string>(); // `${clinicId}:${identifier.toLowerCase()}` -> patientId
@@ -39,6 +45,119 @@ export const patientStore = {
       if (filter?.status && p.status !== filter.status) return false;
       return true;
     });
+  },
+
+  /**
+   * Case-insensitive partial search across `givenName` and `familyName`,
+   * scoped to a single `clinicId`. Returns the sanitized `PatientListItem`
+   * shape (no phone/email/address/birthDate). Capped at 50 results per
+   * query.
+   */
+  findByClinicAndName(
+    clinicId: string,
+    query: string,
+    limit: number = 50,
+  ): PatientListItem[] {
+    if (typeof query !== "string") return [];
+    const q = query.trim().toLowerCase();
+    if (q.length === 0) return [];
+    const cap = Math.min(Math.max(limit, 1), 50);
+    const out: PatientListItem[] = [];
+    for (const p of store.values()) {
+      if (p.clinicId !== clinicId) continue;
+      const given = p.givenName.toLowerCase();
+      const family = p.familyName.toLowerCase();
+      if (given.includes(q) || family.includes(q)) {
+        out.push({
+          patientId: p.patientId,
+          clinicId: p.clinicId,
+          identifier: p.identifier,
+          givenName: p.givenName,
+          familyName: p.familyName,
+          status: p.status,
+        });
+        if (out.length >= cap) break;
+      }
+    }
+    return out;
+  },
+
+  /**
+   * Paginated list of patients within a clinic, with simple offset/limit
+   * pagination. Hard caps: `limit` 1..50 (default 25), `offset` ≥ 0.
+   */
+  listPaginated(
+    clinicId: string,
+    opts: { limit?: number; offset?: number } = {},
+  ): PatientListPage {
+    const limit = Math.min(Math.max(opts.limit ?? 25, 1), 50);
+    const offset = Math.max(opts.offset ?? 0, 0);
+    const all = Array.from(store.values()).filter(
+      (p) => p.clinicId === clinicId,
+    );
+    const slice = all.slice(offset, offset + limit);
+    return {
+      items: slice.map((p) => ({
+        patientId: p.patientId,
+        clinicId: p.clinicId,
+        identifier: p.identifier,
+        givenName: p.givenName,
+        familyName: p.familyName,
+        status: p.status,
+      })),
+      total: all.length,
+      limit,
+      offset,
+    };
+  },
+
+  /**
+   * Strict save: write only when the (clinicId, identifier) pair is unused
+   * by any *other* patient. Re-saving the same patient with the same
+   * identifier is allowed (idempotent update). Differs from `save` which
+   * silently overwrites the index.
+   */
+  saveStrict(
+    patient: Patient,
+  ):
+    | { ok: true; patient: Patient }
+    | { ok: false; error: PatientErrorCode; message: string } {
+    const existingId = identifierIndex.get(
+      indexKey(patient.clinicId, patient.identifier),
+    );
+    if (existingId && existingId !== patient.patientId) {
+      return {
+        ok: false,
+        error: "PATIENT_IDENTIFIER_TAKEN",
+        message:
+          "this medical record number is already in use in this clinic",
+      };
+    }
+    store.set(patient.patientId, patient);
+    identifierIndex.set(
+      indexKey(patient.clinicId, patient.identifier),
+      patient.patientId,
+    );
+    return { ok: true, patient };
+  },
+
+  /**
+   * Mark an existing patient as archived. Sets `status='archived'`, stamps
+   * `archivedAt` with the current ISO timestamp, and bumps `updatedAt`.
+   * Returns null when the patient does not exist.
+   */
+  archiveById(patientId: string): Patient | null {
+    const p = store.get(patientId);
+    if (!p) return null;
+    const now = new Date().toISOString();
+    const archived: Patient = {
+      ...p,
+      status: "archived",
+      archivedAt: now,
+      updatedAt: now,
+    };
+    store.set(patientId, archived);
+    return archived;
   },
 
   _reset(): void {

--- a/apps/api/src/modules/patient/routes/index.ts
+++ b/apps/api/src/modules/patient/routes/index.ts
@@ -1,0 +1,49 @@
+import { Router } from "express";
+import { resolveAuthContext } from "../../../shared/middleware/auth-context.js";
+import { requirePermission } from "../../../shared/middleware/role-guard.js";
+import {
+  create,
+  get,
+  list,
+  update,
+  archive,
+} from "../controllers/patient.controller.js";
+
+const router = Router();
+
+router.post(
+  "/",
+  resolveAuthContext,
+  requirePermission("patient:write"),
+  create,
+);
+
+router.get(
+  "/",
+  resolveAuthContext,
+  requirePermission("patient:read"),
+  list,
+);
+
+router.get(
+  "/:patientId",
+  resolveAuthContext,
+  requirePermission("patient:read"),
+  get,
+);
+
+router.patch(
+  "/:patientId",
+  resolveAuthContext,
+  requirePermission("patient:write"),
+  update,
+);
+
+router.delete(
+  "/:patientId",
+  resolveAuthContext,
+  requirePermission("patient:write"),
+  archive,
+);
+
+export { router as patientRouter };

--- a/apps/api/src/modules/patient/services/patient.service.ts
+++ b/apps/api/src/modules/patient/services/patient.service.ts
@@ -1,0 +1,167 @@
+import { randomUUID } from "crypto";
+import type {
+  Patient,
+  PatientStatus,
+  PatientErrorCode,
+  PatientListPage,
+  CreatePatientRequest,
+  UpdatePatientRequest,
+} from "@lumen/types";
+import { patientStore } from "../repositories/patient.repository.js";
+
+/**
+ * Create a new patient record in the caller's clinic.
+ *
+ * Returns the new patient on success, or a typed error envelope
+ * (`{ error: PatientErrorCode; message: string }`) when the medical
+ * record number is already in use in this clinic.
+ *
+ * Input shape is treated as already-validated upstream by the controller's
+ * call to `validateCreatePatient`; the service does not re-validate.
+ *
+ * Note: creator-audit is intentionally out of scope for this PR.
+ * When `Patient` gains a `createdBy: string` field, plumb it through
+ * here (mirrors what `clinicService.createClinic` does with `ownerId`
+ * and `Clinic.ownerId`).
+ */
+export function createPatient(
+  req: CreatePatientRequest,
+  clinicId: string,
+): Patient | { error: PatientErrorCode; message: string } {
+  const now = new Date().toISOString();
+  const patient: Patient = {
+    patientId: randomUUID(),
+    clinicId,
+    identifier: req.identifier.trim(),
+    givenName: req.givenName.trim(),
+    familyName: req.familyName.trim(),
+    birthDate: req.birthDate,
+    phone: req.phone.trim(),
+    email: req.email.trim(),
+    address: req.address.trim(),
+    status: "active",
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  const result = patientStore.saveStrict(patient);
+  if (!result.ok) {
+    return { error: result.error, message: result.message };
+  }
+  return result.patient;
+}
+
+/**
+ * Fetch a single patient by id, scoped to the caller's clinic.
+ * Returns null when the patient does not exist OR belongs to a different
+ * clinic (fail-closed cross-clinic isolation).
+ */
+export function getPatient(
+  patientId: string,
+  callerClinicId: string,
+): Patient | null {
+  const patient = patientStore.findById(patientId);
+  if (!patient || patient.clinicId !== callerClinicId) return null;
+  return patient;
+}
+
+/**
+ * List patients in the caller's clinic, paginated.
+ * Returns the sanitized `PatientListPage` shape (`PatientListItem` entries —
+ * no phone / email / address / birthDate), matching the redaction contract
+ * established in #614.
+ */
+export function listPatients(
+  callerClinicId: string,
+  opts: { limit?: number; offset?: number } = {},
+): PatientListPage {
+  return patientStore.listPaginated(callerClinicId, opts);
+}
+
+/**
+ * Decide the next `Patient.archivedAt` value given prior status and the
+ * patch's optional status. Maintains the invariant: `archivedAt` is set
+ * IFF `status === "archived"`.
+ *
+ * - No status patch → preserve prior archivedAt.
+ * - patch.status === "archived" AND existing was archived → preserve
+ *   prior timestamp (first-archive time is sticky for forensics).
+ * - patch.status === "archived" AND existing was NOT archived → stamp
+ *   now (transition INTO archived).
+ * - patch.status !== "archived" AND existing was archived → undefined
+ *   (transition OUT clears archivedAt).
+ * - patch.status !== "archived" AND existing was NOT archived →
+ *   undefined.
+ */
+function nextArchivedAt(
+  existingStatus: PatientStatus,
+  existingArchivedAt: string | undefined,
+  patchStatus: PatientStatus | undefined,
+): string | undefined {
+  if (patchStatus === undefined) return existingArchivedAt;
+  if (patchStatus === "archived") {
+    if (existingStatus === "archived") return existingArchivedAt;
+    return new Date().toISOString();
+  }
+  // patchStatus !== "archived" — either transitioning OUT of archived
+  // or staying non-archived; in both cases archivedAt is cleared.
+  return undefined;
+}
+
+/**
+ * Patch a patient record. Strictly clinic-isolated (returns null when the
+ * patient is not in the caller's clinic). Identifier is not patchable via
+ * `UpdatePatientRequest`.
+ *
+ * Status ↔ archivedAt transitions (delegated to `nextArchivedAt`):
+ * - Transitioning INTO archived stamps archivedAt.
+ * - Transitioning OUT of archived clears archivedAt.
+ * - Re-applying the same status does not ref-stamp archivedAt.
+ */
+export function updatePatient(
+  patientId: string,
+  callerClinicId: string,
+  patch: UpdatePatientRequest,
+): Patient | null {
+  const existing = getPatient(patientId, callerClinicId);
+  if (!existing) return null;
+
+  const newArchivedAt = nextArchivedAt(
+    existing.status,
+    existing.archivedAt,
+    patch.status,
+  );
+
+  // Drop existing.archivedAt before applying the patch so the field is
+  // truly absent (not just undefined-valued) when transitioning OUT.
+  const { archivedAt: _, ...rest } = existing;
+
+  const updated: Patient = {
+    ...rest,
+    ...(patch.givenName ? { givenName: patch.givenName.trim() } : {}),
+    ...(patch.familyName ? { familyName: patch.familyName.trim() } : {}),
+    ...(patch.phone ? { phone: patch.phone.trim() } : {}),
+    ...(patch.email ? { email: patch.email.trim() } : {}),
+    ...(patch.address ? { address: patch.address.trim() } : {}),
+    ...(patch.status ? { status: patch.status } : {}),
+    ...(newArchivedAt !== undefined ? { archivedAt: newArchivedAt } : {}),
+    updatedAt: new Date().toISOString(),
+  };
+
+  // Identifier is not patched; saveStrict's collision check is unnecessary.
+  return patientStore.save(updated);
+}
+
+/**
+ * Mark a patient as archived (sets `status='archived'`, stamps
+ * `archivedAt`). Returns null when the patient is not in the caller's
+ * clinic.
+ */
+export function archivePatient(
+  patientId: string,
+  callerClinicId: string,
+): Patient | null {
+  const existing = getPatient(patientId, callerClinicId);
+  if (!existing) return null;
+  return patientStore.archiveById(patientId);
+}

--- a/apps/api/src/modules/patient/tests/patient.controller.test.ts
+++ b/apps/api/src/modules/patient/tests/patient.controller.test.ts
@@ -1,0 +1,577 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import express from "express";
+import type { Express } from "express";
+import type { UserRole } from "@lumen/types";
+import { patientRouter } from "../routes/index.js";
+import { patientStore } from "../repositories/patient.repository.js";
+import { identityStore } from "../../auth/repositories/identity.repository.js";
+import { sessionStore } from "../../auth/repositories/session.repository.js";
+import { _resetAuthStateForTests } from "../../auth/controllers/auth.controller.js";
+import { buildTwoClinicFixture } from "../../auth/tests/fixtures.js";
+import { accessTokenSigner } from "../../auth/services/token.service.js";
+
+function tokenWithRole(clinicId: string, role: UserRole): string {
+  return accessTokenSigner.sign({
+    sub: `user-${role}-${clinicId}`,
+    clinicId,
+    role,
+  });
+}
+
+function buildApp(): Express {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/v1/patients", patientRouter);
+  return app;
+}
+
+async function req(
+  app: Express,
+  method: "GET" | "POST" | "PATCH" | "DELETE",
+  path: string,
+  body?: unknown,
+  token?: string,
+): Promise<{ status: number; body: unknown }> {
+  const { createServer } = await import("http");
+  return new Promise((resolve, reject) => {
+    const server = createServer(app);
+    server.listen(0, () => {
+      const port = (server.address() as { port: number }).port;
+      fetch(`http://localhost:${port}${path}`, {
+        method,
+        headers: {
+          "Content-Type": "application/json",
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+      })
+        .then(async (res) => {
+          const json = await res.json();
+          server.close();
+          resolve({ status: res.status, body: json });
+        })
+        .catch((err) => {
+          server.close();
+          reject(err);
+        });
+    });
+  });
+}
+
+const VALID_BODY = {
+  identifier: "MRN-001",
+  givenName: "Ada",
+  familyName: "Lovelace",
+  birthDate: "1815-12-10",
+  phone: "+441234567890",
+  email: "ada@example.com",
+  address: "1 Science Park",
+};
+
+describe("POST /api/v1/patients — create", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    _resetAuthStateForTests();
+    identityStore._reset();
+    sessionStore._reset();
+    patientStore._reset();
+  });
+
+  it("returns 201 with the created patient for an owner", async () => {
+    const { a } = buildTwoClinicFixture();
+    const { status, body } = await req(
+      app,
+      "POST",
+      "/api/v1/patients",
+      VALID_BODY,
+      a.token,
+    );
+    expect(status).toBe(201);
+    const patient = (
+      body as { patient: { patientId: string; status: string } }
+    ).patient;
+    expect(typeof patient.patientId).toBe("string");
+    expect(patient.status).toBe("active");
+  });
+
+  it("returns 409 with PATIENT_IDENTIFIER_TAKEN on duplicate MRN in same clinic", async () => {
+    const { a } = buildTwoClinicFixture();
+    await req(app, "POST", "/api/v1/patients", VALID_BODY, a.token);
+    const { status, body } = await req(
+      app,
+      "POST",
+      "/api/v1/patients",
+      VALID_BODY,
+      a.token,
+    );
+    expect(status).toBe(409);
+    expect((body as { error: string }).error).toBe("PATIENT_IDENTIFIER_TAKEN");
+  });
+
+  it("returns 400 with field context on invalid email", async () => {
+    const { a } = buildTwoClinicFixture();
+    const { status, body } = await req(
+      app,
+      "POST",
+      "/api/v1/patients",
+      { ...VALID_BODY, email: "not-an-email" },
+      a.token,
+    );
+    expect(status).toBe(400);
+    expect((body as { field: string }).field).toBe("email");
+  });
+
+  it("returns 400 with field context on missing birthDate", async () => {
+    const { a } = buildTwoClinicFixture();
+    const { status, body } = await req(
+      app,
+      "POST",
+      "/api/v1/patients",
+      { ...VALID_BODY, birthDate: "12/10/1815" },
+      a.token,
+    );
+    expect(status).toBe(400);
+    expect((body as { field: string }).field).toBe("birthDate");
+  });
+
+  it("returns 403 when a cashier tries to create", async () => {
+    const { a } = buildTwoClinicFixture();
+    const cashierToken = tokenWithRole(a.clinicId, "cashier");
+    const { status, body } = await req(
+      app,
+      "POST",
+      "/api/v1/patients",
+      VALID_BODY,
+      cashierToken,
+    );
+    expect(status).toBe(403);
+    expect((body as { error: string }).error).toBe("AUTH_FORBIDDEN");
+  });
+
+  it("returns 200 for a clinician (front-desk write path)", async () => {
+    const { a } = buildTwoClinicFixture();
+    const clinicianToken = tokenWithRole(a.clinicId, "clinician");
+    const { status } = await req(
+      app,
+      "POST",
+      "/api/v1/patients",
+      VALID_BODY,
+      clinicianToken,
+    );
+    expect(status).toBe(201);
+  });
+
+  it("returns 401 with no token", async () => {
+    const { status } = await req(app, "POST", "/api/v1/patients", VALID_BODY);
+    expect(status).toBe(401);
+  });
+});
+
+describe("GET /api/v1/patients — list", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    _resetAuthStateForTests();
+    identityStore._reset();
+    sessionStore._reset();
+    patientStore._reset();
+  });
+
+  it("returns 200 with paginated patients scoped to caller's clinic", async () => {
+    const { a } = buildTwoClinicFixture();
+    await req(app, "POST", "/api/v1/patients", VALID_BODY, a.token);
+    await req(
+      app,
+      "POST",
+      "/api/v1/patients",
+      { ...VALID_BODY, identifier: "MRN-2" },
+      a.token,
+    );
+    const { status, body } = await req(
+      app,
+      "GET",
+      "/api/v1/patients?limit=10",
+      undefined,
+      a.token,
+    );
+    expect(status).toBe(200);
+    const page = body as { items: unknown[]; total: number };
+    expect(page.total).toBe(2);
+    expect(page.items).toHaveLength(2);
+  });
+
+  it("returns sanitized PatientListItem shape (no PII)", async () => {
+    const { a } = buildTwoClinicFixture();
+    await req(app, "POST", "/api/v1/patients", VALID_BODY, a.token);
+    const { body } = await req(
+      app,
+      "GET",
+      "/api/v1/patients",
+      undefined,
+      a.token,
+    );
+    const item = (body as { items: Record<string, unknown>[] }).items[0];
+    const allowed = [
+      "clinicId",
+      "familyName",
+      "givenName",
+      "identifier",
+      "patientId",
+      "status",
+    ];
+    expect(Object.keys(item).sort()).toEqual([...allowed].sort());
+  });
+
+  it("returns 403 for a cashier (no patient:read permission)", async () => {
+    const { a } = buildTwoClinicFixture();
+    const cashierToken = tokenWithRole(a.clinicId, "cashier");
+    const { status, body } = await req(
+      app,
+      "GET",
+      "/api/v1/patients",
+      undefined,
+      cashierToken,
+    );
+    expect(status).toBe(403);
+    expect((body as { error: string }).error).toBe("AUTH_FORBIDDEN");
+  });
+
+  it("returns 200 for a clinician", async () => {
+    const { a } = buildTwoClinicFixture();
+    const clinicianToken = tokenWithRole(a.clinicId, "clinician");
+    const { status } = await req(
+      app,
+      "GET",
+      "/api/v1/patients",
+      undefined,
+      clinicianToken,
+    );
+    expect(status).toBe(200);
+  });
+});
+
+describe("GET /api/v1/patients/:patientId — read", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    _resetAuthStateForTests();
+    identityStore._reset();
+    sessionStore._reset();
+    patientStore._reset();
+  });
+
+  it("returns 200 with the patient when caller clinic matches", async () => {
+    const { a } = buildTwoClinicFixture();
+    const created = await req(
+      app,
+      "POST",
+      "/api/v1/patients",
+      VALID_BODY,
+      a.token,
+    );
+    const patientId = (
+      created.body as { patient: { patientId: string } }
+    ).patient.patientId;
+    const { status, body } = await req(
+      app,
+      "GET",
+      `/api/v1/patients/${patientId}`,
+      undefined,
+      a.token,
+    );
+    expect(status).toBe(200);
+    expect(
+      (body as { patient: { patientId: string } }).patient.patientId,
+    ).toBe(patientId);
+  });
+
+  it("returns 404 for a cross-clinic patient (avoids existence enumeration)", async () => {
+    const { a, b } = buildTwoClinicFixture();
+    const created = await req(
+      app,
+      "POST",
+      "/api/v1/patients",
+      VALID_BODY,
+      b.token,
+    );
+    const patientId = (
+      created.body as { patient: { patientId: string } }
+    ).patient.patientId;
+    const { status } = await req(
+      app,
+      "GET",
+      `/api/v1/patients/${patientId}`,
+      undefined,
+      a.token,
+    );
+    expect(status).toBe(404);
+  });
+
+  it("returns 404 for an unknown patientId", async () => {
+    const { a } = buildTwoClinicFixture();
+    const { status } = await req(
+      app,
+      "GET",
+      "/api/v1/patients/does-not-exist",
+      undefined,
+      a.token,
+    );
+    expect(status).toBe(404);
+  });
+
+  it("returns 200 for a clinician (read allowed)", async () => {
+    const { a } = buildTwoClinicFixture();
+    const created = await req(
+      app,
+      "POST",
+      "/api/v1/patients",
+      VALID_BODY,
+      a.token,
+    );
+    const patientId = (
+      created.body as { patient: { patientId: string } }
+    ).patient.patientId;
+    const clinicianToken = tokenWithRole(a.clinicId, "clinician");
+    const { status } = await req(
+      app,
+      "GET",
+      `/api/v1/patients/${patientId}`,
+      undefined,
+      clinicianToken,
+    );
+    expect(status).toBe(200);
+  });
+});
+
+describe("PATCH /api/v1/patients/:patientId — update", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    _resetAuthStateForTests();
+    identityStore._reset();
+    sessionStore._reset();
+    patientStore._reset();
+  });
+
+  it("returns 200 with the patched patient", async () => {
+    const { a } = buildTwoClinicFixture();
+    const created = await req(
+      app,
+      "POST",
+      "/api/v1/patients",
+      VALID_BODY,
+      a.token,
+    );
+    const patientId = (
+      created.body as { patient: { patientId: string } }
+    ).patient.patientId;
+    const { status, body } = await req(
+      app,
+      "PATCH",
+      `/api/v1/patients/${patientId}`,
+      { givenName: "Augusta" },
+      a.token,
+    );
+    expect(status).toBe(200);
+    expect(
+      (body as { patient: { givenName: string } }).patient.givenName,
+    ).toBe("Augusta");
+  });
+
+  it("returns 404 for cross-clinic update attempt", async () => {
+    const { a, b } = buildTwoClinicFixture();
+    const created = await req(
+      app,
+      "POST",
+      "/api/v1/patients",
+      VALID_BODY,
+      b.token,
+    );
+    const patientId = (
+      created.body as { patient: { patientId: string } }
+    ).patient.patientId;
+    const { status } = await req(
+      app,
+      "PATCH",
+      `/api/v1/patients/${patientId}`,
+      { givenName: "Augusta" },
+      a.token,
+    );
+    expect(status).toBe(404);
+  });
+
+  it("returns 400 with field context on invalid update body", async () => {
+    const { a } = buildTwoClinicFixture();
+    const created = await req(
+      app,
+      "POST",
+      "/api/v1/patients",
+      VALID_BODY,
+      a.token,
+    );
+    const patientId = (
+      created.body as { patient: { patientId: string } }
+    ).patient.patientId;
+    const { status } = await req(
+      app,
+      "PATCH",
+      `/api/v1/patients/${patientId}`,
+      { email: "bad" },
+      a.token,
+    );
+    expect(status).toBe(400);
+  });
+
+  it("returns 403 for a cashier (no patient:write permission)", async () => {
+    const { a } = buildTwoClinicFixture();
+    const created = await req(
+      app,
+      "POST",
+      "/api/v1/patients",
+      VALID_BODY,
+      a.token,
+    );
+    const patientId = (
+      created.body as { patient: { patientId: string } }
+    ).patient.patientId;
+    const cashierToken = tokenWithRole(a.clinicId, "cashier");
+    const { status } = await req(
+      app,
+      "PATCH",
+      `/api/v1/patients/${patientId}`,
+      { givenName: "X" },
+      cashierToken,
+    );
+    expect(status).toBe(403);
+  });
+
+  it("returns 200 for a clinician update", async () => {
+    const { a } = buildTwoClinicFixture();
+    const created = await req(
+      app,
+      "POST",
+      "/api/v1/patients",
+      VALID_BODY,
+      a.token,
+    );
+    const patientId = (
+      created.body as { patient: { patientId: string } }
+    ).patient.patientId;
+    const clinicianToken = tokenWithRole(a.clinicId, "clinician");
+    const { status } = await req(
+      app,
+      "PATCH",
+      `/api/v1/patients/${patientId}`,
+      { givenName: "Augusta" },
+      clinicianToken,
+    );
+    expect(status).toBe(200);
+  });
+});
+
+describe("DELETE /api/v1/patients/:patientId — archive", () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    _resetAuthStateForTests();
+    identityStore._reset();
+    sessionStore._reset();
+    patientStore._reset();
+  });
+
+  it("returns 200 with the archived patient for admin", async () => {
+    const { a } = buildTwoClinicFixture();
+    const created = await req(
+      app,
+      "POST",
+      "/api/v1/patients",
+      VALID_BODY,
+      a.token,
+    );
+    const patientId = (
+      created.body as { patient: { patientId: string } }
+    ).patient.patientId;
+    const adminToken = tokenWithRole(a.clinicId, "admin");
+    const { status, body } = await req(
+      app,
+      "DELETE",
+      `/api/v1/patients/${patientId}`,
+      undefined,
+      adminToken,
+    );
+    expect(status).toBe(200);
+    expect(
+      (body as { patient: { status: string } }).patient.status,
+    ).toBe("archived");
+  });
+
+  it("returns 403 for a clinician (only owner or admin may archive)", async () => {
+    const { a } = buildTwoClinicFixture();
+    const created = await req(
+      app,
+      "POST",
+      "/api/v1/patients",
+      VALID_BODY,
+      a.token,
+    );
+    const patientId = (
+      created.body as { patient: { patientId: string } }
+    ).patient.patientId;
+    const clinicianToken = tokenWithRole(a.clinicId, "clinician");
+    const { status, body } = await req(
+      app,
+      "DELETE",
+      `/api/v1/patients/${patientId}`,
+      undefined,
+      clinicianToken,
+    );
+    expect(status).toBe(403);
+    expect((body as { error: string }).error).toBe("AUTH_FORBIDDEN");
+  });
+
+  it("returns 403 for a cashier (route-level permission)", async () => {
+    const { a } = buildTwoClinicFixture();
+    const created = await req(
+      app,
+      "POST",
+      "/api/v1/patients",
+      VALID_BODY,
+      a.token,
+    );
+    const patientId = (
+      created.body as { patient: { patientId: string } }
+    ).patient.patientId;
+    const cashierToken = tokenWithRole(a.clinicId, "cashier");
+    const { status } = await req(
+      app,
+      "DELETE",
+      `/api/v1/patients/${patientId}`,
+      undefined,
+      cashierToken,
+    );
+    expect(status).toBe(403);
+  });
+
+  it("returns 404 for cross-clinic archive attempt", async () => {
+    const { a, b } = buildTwoClinicFixture();
+    const created = await req(
+      app,
+      "POST",
+      "/api/v1/patients",
+      VALID_BODY,
+      b.token,
+    );
+    const patientId = (
+      created.body as { patient: { patientId: string } }
+    ).patient.patientId;
+    const { status } = await req(
+      app,
+      "DELETE",
+      `/api/v1/patients/${patientId}`,
+      undefined,
+      a.token,
+    );
+    expect(status).toBe(404);
+  });
+});

--- a/apps/api/src/modules/patient/tests/patient.repository.test.ts
+++ b/apps/api/src/modules/patient/tests/patient.repository.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { Patient, PatientStatus } from "@lumen/types";
+import { patientStore } from "../repositories/patient.repository.js";
+import {
+  validateCreatePatient,
+  validateUpdatePatient,
+} from "../validators/patient.validator.js";
+
+function makePatient(overrides: Partial<Patient> = {}): Patient {
+  const now = "2026-01-01T00:00:00.000Z";
+  return {
+    patientId: overrides.patientId ?? "pat_test_1",
+    clinicId: overrides.clinicId ?? "clinic_a",
+    identifier: overrides.identifier ?? "MRN-001",
+    givenName: overrides.givenName ?? "Ada",
+    familyName: overrides.familyName ?? "Lovelace",
+    birthDate: overrides.birthDate ?? "1815-12-10",
+    phone: overrides.phone ?? "+441234567890",
+    email: overrides.email ?? "ada@example.com",
+    address: overrides.address ?? "1 Science Park",
+    status: overrides.status ?? ("active" as PatientStatus),
+    createdAt: overrides.createdAt ?? now,
+    updatedAt: overrides.updatedAt ?? now,
+  };
+}
+
+describe("patientStore", () => {
+  beforeEach(() => {
+    patientStore._reset();
+  });
+
+  it("saves and retrieves a patient by id", () => {
+    patientStore.save(makePatient({ patientId: "pat_1" }));
+    expect(patientStore.findById("pat_1")?.identifier).toBe("MRN-001");
+  });
+
+  it("returns undefined for an unknown id", () => {
+    expect(patientStore.findById("missing")).toBeUndefined();
+  });
+
+  it("finds by (clinicId, identifier) case-insensitively", () => {
+    patientStore.save(makePatient({ patientId: "pat_1", identifier: "MRN-001" }));
+    patientStore.save(
+      makePatient({ patientId: "pat_2", clinicId: "clinic_b", identifier: "mrn-001" }),
+    );
+    expect(patientStore.findByIdentifier("clinic_a", "MRN-001")?.patientId).toBe("pat_1");
+    expect(patientStore.findByIdentifier("clinic_a", "mrn-001")?.patientId).toBe("pat_1");
+    expect(patientStore.findByIdentifier("clinic_b", "MRN-001")?.patientId).toBe("pat_2");
+  });
+
+  it("distinguishes the same identifier across different clinics", () => {
+    patientStore.save(makePatient({ patientId: "p1", clinicId: "a", identifier: "X" }));
+    patientStore.save(makePatient({ patientId: "p2", clinicId: "b", identifier: "X" }));
+    expect(patientStore.findByIdentifier("a", "X")?.patientId).toBe("p1");
+    expect(patientStore.findByIdentifier("b", "X")?.patientId).toBe("p2");
+  });
+
+  it("lists with optional clinicId and status filters", () => {
+    patientStore.save(makePatient({ patientId: "p1", clinicId: "a", status: "active" }));
+    patientStore.save(makePatient({ patientId: "p2", clinicId: "a", status: "inactive" }));
+    patientStore.save(makePatient({ patientId: "p3", clinicId: "b", status: "active" }));
+
+    expect(patientStore.list()).toHaveLength(3);
+    expect(patientStore.list({ clinicId: "a" })).toHaveLength(2);
+    expect(patientStore.list({ clinicId: "a", status: "active" })).toHaveLength(1);
+    expect(patientStore.list({ status: "active" })).toHaveLength(2);
+  });
+
+  it("_reset clears the store and the identifier index", () => {
+    patientStore.save(makePatient({ identifier: "MRN-001" }));
+    patientStore._reset();
+    expect(patientStore.list()).toHaveLength(0);
+    expect(patientStore.findByIdentifier("clinic_a", "MRN-001")).toBeUndefined();
+  });
+});
+
+const VALID = {
+  identifier: "MRN-001",
+  givenName: "Ada",
+  familyName: "Lovelace",
+  birthDate: "1815-12-10",
+  phone: "+441234567890",
+  email: "ada@example.com",
+  address: "1 Science Park",
+};
+
+describe("validateCreatePatient", () => {
+  it("accepts a well-formed body", () => {
+    expect(validateCreatePatient(VALID).ok).toBe(true);
+  });
+
+  it("rejects a malformed birthDate", () => {
+    const result = validateCreatePatient({ ...VALID, birthDate: "12/10/1815" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.field).toBe("birthDate");
+  });
+
+  it("rejects a malformed email", () => {
+    const result = validateCreatePatient({ ...VALID, email: "not-an-email" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.field).toBe("email");
+  });
+
+  it("rejects an empty required string field", () => {
+    const result = validateCreatePatient({ ...VALID, givenName: "" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.field).toBe("givenName");
+  });
+
+  it("rejects a phone outside the min/max length", () => {
+    expect(validateCreatePatient({ ...VALID, phone: "12" }).ok).toBe(false);
+    expect(
+      validateCreatePatient({ ...VALID, phone: "1".repeat(40) }).ok,
+    ).toBe(false);
+  });
+
+  it("rejects givenName longer than 120 characters", () => {
+    const result = validateCreatePatient({
+      ...VALID,
+      givenName: "a".repeat(121),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.field).toBe("givenName");
+  });
+
+  it("rejects familyName longer than 120 characters", () => {
+    const result = validateCreatePatient({
+      ...VALID,
+      familyName: "a".repeat(121),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.field).toBe("familyName");
+  });
+
+  it("accepts givenName of exactly 120 characters", () => {
+    const result = validateCreatePatient({
+      ...VALID,
+      givenName: "a".repeat(120),
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts identifier of up to 240 characters", () => {
+    const result = validateCreatePatient({
+      ...VALID,
+      identifier: "I".repeat(240),
+    });
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("validateUpdatePatient", () => {
+  it("accepts a partial body with only allowed fields", () => {
+    expect(validateUpdatePatient({ givenName: "Augusta" }).ok).toBe(true);
+  });
+
+  it("accepts an empty body", () => {
+    expect(validateUpdatePatient({}).ok).toBe(true);
+  });
+
+  it("rejects unknown fields", () => {
+    const result = validateUpdatePatient({ notAField: true });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.field).toBe("notAField");
+  });
+
+  it("rejects an unrecognized status", () => {
+    const result = validateUpdatePatient({ status: "deleted" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.field).toBe("status");
+  });
+
+  it("rejects empty-string optional fields", () => {
+    expect(validateUpdatePatient({ phone: "" }).ok).toBe(false);
+    expect(validateUpdatePatient({ address: "" }).ok).toBe(false);
+  });
+});

--- a/apps/api/src/modules/patient/tests/patient.repository.test.ts
+++ b/apps/api/src/modules/patient/tests/patient.repository.test.ts
@@ -175,3 +175,314 @@ describe("validateUpdatePatient", () => {
     expect(validateUpdatePatient({ address: "" }).ok).toBe(false);
   });
 });
+
+describe("findByClinicAndName", () => {
+  beforeEach(() => {
+    patientStore._reset();
+  });
+
+  it("returns partial matches scoped to clinicId", () => {
+    patientStore.save(
+      makePatient({
+        patientId: "p1",
+        clinicId: "a",
+        givenName: "Ada",
+        familyName: "Lovelace",
+      }),
+    );
+    patientStore.save(
+      makePatient({
+        patientId: "p2",
+        clinicId: "a",
+        givenName: "Alan",
+        familyName: "Turing",
+      }),
+    );
+    patientStore.save(
+      makePatient({
+        patientId: "p3",
+        clinicId: "b",
+        givenName: "Ada",
+        familyName: "Byron",
+      }),
+    );
+
+    expect(
+      patientStore.findByClinicAndName("a", "ada").map((p) => p.patientId),
+    ).toEqual(["p1"]);
+    expect(
+      patientStore.findByClinicAndName("b", "ada").map((p) => p.patientId),
+    ).toEqual(["p3"]);
+  });
+
+  it("is case-insensitive across given and family names", () => {
+    patientStore.save(
+      makePatient({
+        patientId: "p1",
+        clinicId: "clinic_a",
+        givenName: "Ada",
+        familyName: "Lovelace",
+      }),
+    );
+    expect(
+      patientStore
+        .findByClinicAndName("clinic_a", "ADA")
+        .map((p) => p.patientId),
+    ).toEqual(["p1"]);
+    expect(
+      patientStore
+        .findByClinicAndName("clinic_a", "ada")
+        .map((p) => p.patientId),
+    ).toEqual(["p1"]);
+    expect(
+      patientStore
+        .findByClinicAndName("clinic_a", "lovelace")
+        .map((p) => p.patientId),
+    ).toEqual(["p1"]);
+  });
+
+  it("matches partial names by substring", () => {
+    patientStore.save(
+      makePatient({
+        patientId: "p1",
+        clinicId: "clinic_a",
+        givenName: "Augusta",
+        familyName: "Byron",
+      }),
+    );
+    patientStore.save(
+      makePatient({
+        patientId: "p2",
+        clinicId: "clinic_a",
+        givenName: "Algernon",
+        familyName: "Blackwood",
+      }),
+    );
+    expect(
+      patientStore
+        .findByClinicAndName("clinic_a", "al")
+        .map((p) => p.patientId),
+    ).toEqual(["p2"]);
+    expect(
+      patientStore
+        .findByClinicAndName("clinic_a", "au")
+        .map((p) => p.patientId),
+    ).toEqual(["p1"]);
+  });
+
+  it("returns empty for empty or whitespace queries", () => {
+    patientStore.save(makePatient({}));
+    expect(
+      patientStore.findByClinicAndName("clinic_a", ""),
+    ).toEqual([]);
+    expect(
+      patientStore.findByClinicAndName("clinic_a", "   "),
+    ).toEqual([]);
+  });
+
+  it("caps results at the limit", () => {
+    for (let i = 0; i < 60; i++) {
+      patientStore.save(
+        makePatient({
+          patientId: `p${i}`,
+          identifier: `mrn-${i}`,
+          givenName: "Same",
+          familyName: "Name",
+        }),
+      );
+    }
+    expect(
+      patientStore.findByClinicAndName("clinic_a", "same").length,
+    ).toBe(50);
+    expect(
+      patientStore.findByClinicAndName("clinic_a", "same", 5).length,
+    ).toBe(5);
+  });
+});
+
+describe("listPaginated", () => {
+  beforeEach(() => {
+    patientStore._reset();
+  });
+
+  it("paginates and reports total", () => {
+    for (let i = 0; i < 30; i++) {
+      patientStore.save(
+        makePatient({ patientId: `p${i}`, identifier: `mrn-${i}` }),
+      );
+    }
+    const page1 = patientStore.listPaginated("clinic_a", {
+      limit: 10,
+      offset: 0,
+    });
+    expect(page1.items.length).toBe(10);
+    expect(page1.total).toBe(30);
+    expect(page1.limit).toBe(10);
+
+    const page2 = patientStore.listPaginated("clinic_a", {
+      limit: 10,
+      offset: 25,
+    });
+    expect(page2.items.length).toBe(5);
+  });
+
+  it("clamps limit between 1 and 50 and offset ≥ 0", () => {
+    for (let i = 0; i < 60; i++) {
+      patientStore.save(
+        makePatient({ patientId: `p${i}`, identifier: `mrn-${i}` }),
+      );
+    }
+    expect(patientStore.listPaginated("clinic_a", { limit: 0 }).limit).toBe(1);
+    expect(
+      patientStore.listPaginated("clinic_a", { limit: 100 }).limit,
+    ).toBe(50);
+    expect(
+      patientStore.listPaginated("clinic_a", { offset: -5 }).offset,
+    ).toBe(0);
+  });
+
+  it("scopes to clinicId before paginating", () => {
+    patientStore.save(
+      makePatient({ patientId: "p1", clinicId: "a", identifier: "mrn-1" }),
+    );
+    patientStore.save(
+      makePatient({ patientId: "p2", clinicId: "b", identifier: "mrn-2" }),
+    );
+    expect(
+      patientStore.listPaginated("a", { limit: 10 }).total,
+    ).toBe(1);
+    expect(
+      patientStore.listPaginated("b", { limit: 10 }).total,
+    ).toBe(1);
+  });
+});
+
+describe("saveStrict", () => {
+  beforeEach(() => {
+    patientStore._reset();
+  });
+
+  it("returns ok when the (clinicId, identifier) pair is unused", () => {
+    const result = patientStore.saveStrict(makePatient({ patientId: "p1" }));
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.patient.patientId).toBe("p1");
+  });
+
+  it("returns ok when re-saving the same patient with same identifier", () => {
+    patientStore.saveStrict(makePatient({ patientId: "p1" }));
+    const result = patientStore.saveStrict(
+      makePatient({ patientId: "p1" }),
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects when a different patient claims the same identifier in the same clinic", () => {
+    patientStore.saveStrict(
+      makePatient({ patientId: "p1", identifier: "MRN-1" }),
+    );
+    const result = patientStore.saveStrict(
+      makePatient({ patientId: "p2", identifier: "MRN-1" }),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBe("PATIENT_IDENTIFIER_TAKEN");
+  });
+
+  it("allows the same identifier across different clinics", () => {
+    patientStore.saveStrict(
+      makePatient({ patientId: "p1", clinicId: "a", identifier: "X" }),
+    );
+    const result = patientStore.saveStrict(
+      makePatient({ patientId: "p2", clinicId: "b", identifier: "X" }),
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it("returns PATIENT_IDENTIFIER_TAKEN with a non-empty message on rejection", () => {
+    patientStore.saveStrict(
+      makePatient({ patientId: "p1", identifier: "MRN-1" }),
+    );
+    const result = patientStore.saveStrict(
+      makePatient({ patientId: "p2", identifier: "MRN-1" }),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("PATIENT_IDENTIFIER_TAKEN");
+      expect(typeof result.message).toBe("string");
+      expect(result.message.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+it("saveStrict preserves the identifier index when rejecting a duplicate", () => {
+  patientStore.saveStrict(
+    makePatient({ patientId: "p1", identifier: "MRN-1" }),
+  );
+  patientStore.saveStrict(
+    makePatient({ patientId: "p2", identifier: "MRN-1" }),
+  );
+  expect(
+    patientStore.findByIdentifier("clinic_a", "MRN-1")?.patientId,
+  ).toBe("p1");
+});
+
+it("archiveById preserves the identifier index", () => {
+  patientStore.save(makePatient({ patientId: "p1", identifier: "MRN-1" }));
+  patientStore.archiveById("p1");
+  expect(
+    patientStore.findByIdentifier("clinic_a", "MRN-1")?.patientId,
+  ).toBe("p1");
+  expect(patientStore.findById("p1")?.status).toBe("archived");
+});
+
+it("listPaginated returns results in stable insertion order", () => {
+  patientStore.save(makePatient({ patientId: "p1", identifier: "mrn-1" }));
+  patientStore.save(makePatient({ patientId: "p2", identifier: "mrn-2" }));
+  patientStore.save(makePatient({ patientId: "p3", identifier: "mrn-3" }));
+  const page = patientStore.listPaginated("clinic_a", {
+    limit: 10,
+    offset: 0,
+  });
+  expect(page.items.map((x) => x.patientId)).toEqual(["p1", "p2", "p3"]);
+});
+
+it("findByClinicAndName returns only the sanitized PatientListItem shape", () => {
+  patientStore._reset();
+  patientStore.save(makePatient({ patientId: "p1" }));
+  const result = patientStore.findByClinicAndName("clinic_a", "ada");
+  expect(result).toHaveLength(1);
+  const item = result[0];
+  expect(item.patientId).toBe("p1");
+  // Structural absence of disallowed PII fields. PatientListItem should only
+  // expose patientId, clinicId, identifier, givenName, familyName, status.
+  const allowedKeys = [
+    "patientId",
+    "clinicId",
+    "identifier",
+    "givenName",
+    "familyName",
+    "status",
+  ];
+  const itemKeys = Object.keys(item);
+  expect(itemKeys.sort()).toEqual(allowedKeys.sort());
+});
+
+describe("archiveById", () => {
+  beforeEach(() => {
+    patientStore._reset();
+  });
+
+  it("returns null for an unknown id", () => {
+    expect(patientStore.archiveById("missing")).toBeNull();
+  });
+
+  it("sets status='archived' and stamps archivedAt", () => {
+    patientStore.save(
+      makePatient({ patientId: "p1", status: "active" }),
+    );
+    const archived = patientStore.archiveById("p1");
+    expect(archived).not.toBeNull();
+    expect(archived!.status).toBe("archived");
+    expect(typeof archived!.archivedAt).toBe("string");
+    expect(archived!.archivedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+});

--- a/apps/api/src/modules/patient/tests/patient.service.test.ts
+++ b/apps/api/src/modules/patient/tests/patient.service.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { CreatePatientRequest, Patient } from "@lumen/types";
+import { patientStore } from "../repositories/patient.repository.js";
+import {
+  createPatient,
+  getPatient,
+  listPatients,
+  updatePatient,
+  archivePatient,
+} from "../services/patient.service.js";
+
+function makeRequest(
+  overrides: Partial<CreatePatientRequest> = {},
+): CreatePatientRequest {
+  return {
+    identifier: overrides.identifier ?? "MRN-001",
+    givenName: overrides.givenName ?? "Ada",
+    familyName: overrides.familyName ?? "Lovelace",
+    birthDate: overrides.birthDate ?? "1815-12-10",
+    phone: overrides.phone ?? "+441234567890",
+    email: overrides.email ?? "ada@example.com",
+    address: overrides.address ?? "1 Science Park",
+  };
+}
+
+function expectSuccess(result: Patient | { error: string; message: string }): Patient {
+  if ("error" in result) {
+    throw new Error(`expected success but got error: ${result.error}`);
+  }
+  return result;
+}
+
+describe("patient.service — createPatient", () => {
+  beforeEach(() => {
+    patientStore._reset();
+  });
+
+  it("creates a new patient with a UUID, status=active, and ISO timestamps", () => {
+    const result = createPatient(makeRequest(), "clinic_a");
+    const patient = expectSuccess(result);
+    expect(patient.patientId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    );
+    expect(patient.clinicId).toBe("clinic_a");
+    expect(patient.status).toBe("active");
+    expect(patient.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(patient.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("trims whitespace on string fields", () => {
+    const patient = expectSuccess(
+      createPatient(
+        makeRequest({
+          givenName: "  Ada  ",
+          familyName: "Lovelace",
+          address: "  1 Science Park  ",
+        }),
+        "clinic_a",
+      ),
+    );
+    expect(patient.givenName).toBe("Ada");
+    expect(patient.address).toBe("1 Science Park");
+  });
+
+  it("returns PATIENT_IDENTIFIER_TAKEN when same identifier in same clinic", () => {
+    expectSuccess(createPatient(makeRequest({ identifier: "MRN-DUP" }), "clinic_a"));
+    const result = createPatient(
+      makeRequest({ identifier: "MRN-DUP" }),
+      "clinic_a",
+    );
+    if (!("error" in result)) {
+      throw new Error("expected error on duplicate, got patient");
+    }
+    expect(result.error).toBe("PATIENT_IDENTIFIER_TAKEN");
+    expect(typeof result.message).toBe("string");
+    expect(result.message.length).toBeGreaterThan(0);
+  });
+
+  it("allows the same identifier across different clinics", () => {
+    const a = expectSuccess(createPatient(makeRequest({ identifier: "X" }), "clinic_a"));
+    const b = expectSuccess(createPatient(makeRequest({ identifier: "X" }), "clinic_b"));
+    expect(a.patientId).not.toBe(b.patientId);
+  });
+});
+
+describe("patient.service — getPatient", () => {
+  beforeEach(() => {
+    patientStore._reset();
+  });
+
+  it("returns the patient when callerClinicId matches", () => {
+    const created = expectSuccess(createPatient(makeRequest(), "clinic_a"));
+    const fetched = getPatient(created.patientId, "clinic_a");
+    expect(fetched).not.toBeNull();
+    expect(fetched?.patientId).toBe(created.patientId);
+  });
+
+  it("returns null when callerClinicId is a different clinic", () => {
+    const created = expectSuccess(createPatient(makeRequest(), "clinic_a"));
+    expect(getPatient(created.patientId, "clinic_b")).toBeNull();
+  });
+
+  it("returns null for an unknown patientId", () => {
+    expect(getPatient("does-not-exist", "clinic_a")).toBeNull();
+  });
+});
+
+describe("patient.service — listPatients", () => {
+  beforeEach(() => {
+    patientStore._reset();
+  });
+
+  it("returns paginated results scoped to callerClinicId", () => {
+    expectSuccess(createPatient(makeRequest({ identifier: "A" }), "clinic_a"));
+    expectSuccess(createPatient(makeRequest({ identifier: "B" }), "clinic_a"));
+    expectSuccess(createPatient(makeRequest({ identifier: "C" }), "clinic_a"));
+    expectSuccess(createPatient(makeRequest({ identifier: "X" }), "clinic_b"));
+
+    const page = listPatients("clinic_a", { limit: 10, offset: 0 });
+    expect(page.total).toBe(3);
+    expect(page.items).toHaveLength(3);
+    expect(page.limit).toBe(10);
+    expect(page.offset).toBe(0);
+  });
+
+  it("respects limit and offset", () => {
+    for (let i = 0; i < 30; i++) {
+      expectSuccess(
+        createPatient(makeRequest({ identifier: `mrn-${i}` }), "clinic_a"),
+      );
+    }
+    const first = listPatients("clinic_a", { limit: 10, offset: 0 });
+    const second = listPatients("clinic_a", { limit: 10, offset: 25 });
+    expect(first.items).toHaveLength(10);
+    expect(second.items).toHaveLength(5);
+    expect(first.total).toBe(30);
+  });
+
+  it("returns only the sanitized PatientListItem shape (no PII)", () => {
+    expectSuccess(createPatient(makeRequest(), "clinic_a"));
+    const page = listPatients("clinic_a");
+    expect(page.items).toHaveLength(1);
+    const item = page.items[0];
+    const allowedKeys = [
+      "clinicId",
+      "familyName",
+      "givenName",
+      "identifier",
+      "patientId",
+      "status",
+    ];
+    expect(Object.keys(item).sort()).toEqual([...allowedKeys].sort());
+  });
+
+  it("returns an empty page for an unknown clinic", () => {
+    expectSuccess(createPatient(makeRequest(), "clinic_a"));
+    const page = listPatients("clinic_unknown");
+    expect(page.total).toBe(0);
+    expect(page.items).toEqual([]);
+  });
+});
+
+describe("patient.service — updatePatient", () => {
+  beforeEach(() => {
+    patientStore._reset();
+  });
+
+  it("applies a partial patch and bumps updatedAt", () => {
+    const created = expectSuccess(createPatient(makeRequest(), "clinic_a"));
+    const patched = updatePatient(created.patientId, "clinic_a", {
+      givenName: "Augusta",
+    });
+    expect(patched).not.toBeNull();
+    expect(patched?.givenName).toBe("Augusta");
+    expect(patched?.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("leaves fields unset in the patch unchanged", () => {
+    const created = expectSuccess(createPatient(makeRequest(), "clinic_a"));
+    const patched = updatePatient(created.patientId, "clinic_a", {
+      phone: "+15555550100",
+    });
+    expect(patched?.phone).toBe("+15555550100");
+    expect(patched?.givenName).toBe(created.givenName);
+    expect(patched?.email).toBe(created.email);
+  });
+
+  it("returns null when callerClinicId is a different clinic", () => {
+    const created = expectSuccess(createPatient(makeRequest(), "clinic_a"));
+    expect(
+      updatePatient(created.patientId, "clinic_b", { givenName: "X" }),
+    ).toBeNull();
+  });
+
+  it("returns null for an unknown patientId", () => {
+    expect(
+      updatePatient("does-not-exist", "clinic_a", { givenName: "X" }),
+    ).toBeNull();
+  });
+
+  it("sets archivedAt when transitioning status to 'archived'", () => {
+    const created = expectSuccess(createPatient(makeRequest(), "clinic_a"));
+    const patched = updatePatient(created.patientId, "clinic_a", {
+      status: "archived",
+    });
+    expect(patched).not.toBeNull();
+    expect(patched?.status).toBe("archived");
+    expect(patched?.archivedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("clears archivedAt when transitioning status away from 'archived'", () => {
+    const created = expectSuccess(createPatient(makeRequest(), "clinic_a"));
+    expect(archivePatient(created.patientId, "clinic_a")).not.toBeNull();
+    const patched = updatePatient(created.patientId, "clinic_a", {
+      status: "inactive",
+    });
+    expect(patched).not.toBeNull();
+    expect(patched?.status).toBe("inactive");
+    expect(patched?.archivedAt).toBeUndefined();
+  });
+
+  it("preserves archivedAt when an archived patient receives a non-status patch", () => {
+    const created = expectSuccess(createPatient(makeRequest(), "clinic_a"));
+    expect(archivePatient(created.patientId, "clinic_a")).not.toBeNull();
+    const prior = getPatient(created.patientId, "clinic_a");
+    expect(prior?.archivedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    const patched = updatePatient(created.patientId, "clinic_a", {
+      phone: "+15555550100",
+    });
+    expect(patched).not.toBeNull();
+    expect(patched?.status).toBe("archived");
+    expect(patched?.archivedAt).toBe(prior?.archivedAt);
+  });
+
+  it("does not set archivedAt for a non-status patch on a non-archived patient", () => {
+    const created = expectSuccess(createPatient(makeRequest(), "clinic_a"));
+    const patched = updatePatient(created.patientId, "clinic_a", {
+      phone: "+15555550100",
+    });
+    expect(patched).not.toBeNull();
+    expect(patched?.status).toBe("active");
+    expect(patched?.archivedAt).toBeUndefined();
+  });
+
+  it("preserves archivedAt when an archived patient receives a redundant archive patch", () => {
+    const created = expectSuccess(createPatient(makeRequest(), "clinic_a"));
+    expect(archivePatient(created.patientId, "clinic_a")).not.toBeNull();
+    const prior = getPatient(created.patientId, "clinic_a");
+    expect(prior?.archivedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    const patched = updatePatient(created.patientId, "clinic_a", {
+      status: "archived",
+    });
+    expect(patched).not.toBeNull();
+    expect(patched?.status).toBe("archived");
+    expect(patched?.archivedAt).toBe(prior?.archivedAt);
+  });
+});
+
+describe("patient.service — archivePatient", () => {
+  beforeEach(() => {
+    patientStore._reset();
+  });
+
+  it("sets status='archived' and stamps archivedAt on success", () => {
+    const created = expectSuccess(createPatient(makeRequest(), "clinic_a"));
+    const archived = archivePatient(created.patientId, "clinic_a");
+    expect(archived).not.toBeNull();
+    expect(archived?.status).toBe("archived");
+    expect(typeof archived?.archivedAt).toBe("string");
+    expect(archived?.archivedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("returns null when callerClinicId is a different clinic", () => {
+    const created = expectSuccess(createPatient(makeRequest(), "clinic_a"));
+    expect(archivePatient(created.patientId, "clinic_b")).toBeNull();
+  });
+
+  it("returns null for an unknown patientId", () => {
+    expect(archivePatient("does-not-exist", "clinic_a")).toBeNull();
+  });
+});

--- a/apps/api/src/modules/patient/types/index.ts
+++ b/apps/api/src/modules/patient/types/index.ts
@@ -4,6 +4,7 @@ export type {
   CreatePatientRequest,
   UpdatePatientRequest,
   PatientListItem,
+  PatientListPage,
   PatientErrorCode,
   PatientError,
 } from "@lumen/types";

--- a/apps/api/src/modules/patient/types/index.ts
+++ b/apps/api/src/modules/patient/types/index.ts
@@ -1,0 +1,9 @@
+export type {
+  Patient,
+  PatientStatus,
+  CreatePatientRequest,
+  UpdatePatientRequest,
+  PatientListItem,
+  PatientErrorCode,
+  PatientError,
+} from "@lumen/types";

--- a/apps/api/src/modules/patient/validators/patient.validator.ts
+++ b/apps/api/src/modules/patient/validators/patient.validator.ts
@@ -1,0 +1,177 @@
+import type {
+  CreatePatientRequest,
+  UpdatePatientRequest,
+} from "@lumen/types";
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const MAX_NAME_LEN = 120;
+const MAX_ADDR_LEN = 240;
+const MIN_PHONE_LEN = 5;
+const MAX_PHONE_LEN = 32;
+
+type ValidationResult =
+  | { ok: true }
+  | { ok: false; field: string; message: string };
+
+function requireString(
+  body: Record<string, unknown>,
+  field: keyof CreatePatientRequest,
+  min: number,
+  max: number,
+): ValidationResult | null {
+  const v = body[field];
+  if (v === undefined || v === null) {
+    return { ok: false, field, message: `${field} is required` };
+  }
+  if (typeof v !== "string" || v.trim().length < min) {
+    return {
+      ok: false,
+      field,
+      message: `${field} must be at least ${min} characters`,
+    };
+  }
+  if (v.trim().length > max) {
+    return {
+      ok: false,
+      field,
+      message: `${field} must be ${max} characters or fewer`,
+    };
+  }
+  return null;
+}
+
+export function validateCreatePatient(body: unknown): ValidationResult {
+  const b = (body ?? {}) as Partial<CreatePatientRequest> as Record<
+    string,
+    unknown
+  >;
+
+  const ADDR_LIKE: ReadonlyArray<keyof CreatePatientRequest> = [
+    "identifier",
+    "address",
+  ];
+  const NAME_LIKE: ReadonlyArray<keyof CreatePatientRequest> = [
+    "givenName",
+    "familyName",
+  ];
+
+  for (const field of ADDR_LIKE) {
+    const err = requireString(b, field, 1, MAX_ADDR_LEN);
+    if (err) return err;
+  }
+  for (const field of NAME_LIKE) {
+    const err = requireString(b, field, 1, MAX_NAME_LEN);
+    if (err) return err;
+  }
+
+  const bd = b.birthDate;
+  if (typeof bd !== "string" || !ISO_DATE_RE.test(bd)) {
+    return {
+      ok: false,
+      field: "birthDate",
+      message: "birthDate must be an ISO-8601 date (YYYY-MM-DD)",
+    };
+  }
+
+  if (
+    typeof b.phone !== "string" ||
+    b.phone.trim().length < MIN_PHONE_LEN ||
+    b.phone.trim().length > MAX_PHONE_LEN
+  ) {
+    return {
+      ok: false,
+      field: "phone",
+      message: `phone must be between ${MIN_PHONE_LEN} and ${MAX_PHONE_LEN} characters`,
+    };
+  }
+
+  if (typeof b.email !== "string" || !EMAIL_RE.test(b.email)) {
+    return { ok: false, field: "email", message: "a valid email is required" };
+  }
+
+  return { ok: true };
+}
+
+const ALLOWED_UPDATE_FIELDS: ReadonlySet<keyof UpdatePatientRequest> = new Set([
+  "givenName",
+  "familyName",
+  "phone",
+  "email",
+  "address",
+  "status",
+]);
+
+const STATUS_VALUES: ReadonlySet<string> = new Set([
+  "active",
+  "inactive",
+  "archived",
+]);
+
+function validateOptionalString(
+  body: Record<string, unknown>,
+  field: keyof UpdatePatientRequest,
+  min: number,
+  max: number,
+): ValidationResult | null {
+  const v = body[field];
+  if (v === undefined) return null;
+  if (typeof v !== "string" || v.trim().length < min) {
+    return {
+      ok: false,
+      field,
+      message: `${field} must be at least ${min} characters`,
+    };
+  }
+  if (v.trim().length > max) {
+    return {
+      ok: false,
+      field,
+      message: `${field} must be ${max} characters or fewer`,
+    };
+  }
+  return null;
+}
+
+export function validateUpdatePatient(body: unknown): ValidationResult {
+  const b = (body ?? {}) as Partial<UpdatePatientRequest> as Record<
+    string,
+    unknown
+  >;
+
+  let err: ValidationResult | null;
+  err = validateOptionalString(b, "givenName", 1, MAX_NAME_LEN);
+  if (err) return err;
+  err = validateOptionalString(b, "familyName", 1, MAX_NAME_LEN);
+  if (err) return err;
+  err = validateOptionalString(b, "phone", MIN_PHONE_LEN, MAX_PHONE_LEN);
+  if (err) return err;
+  err = validateOptionalString(b, "address", 1, MAX_ADDR_LEN);
+  if (err) return err;
+
+  if (b.email !== undefined) {
+    if (typeof b.email !== "string" || !EMAIL_RE.test(b.email)) {
+      return {
+        ok: false,
+        field: "email",
+        message: "a valid email is required",
+      };
+    }
+  }
+
+  if (b.status !== undefined && !STATUS_VALUES.has(String(b.status))) {
+    return {
+      ok: false,
+      field: "status",
+      message: "status must be one of active|inactive|archived",
+    };
+  }
+
+  for (const k of Object.keys(b)) {
+    if (!ALLOWED_UPDATE_FIELDS.has(k as keyof UpdatePatientRequest)) {
+      return { ok: false, field: k, message: `unknown field ${k}` };
+    }
+  }
+
+  return { ok: true };
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -2,6 +2,7 @@ export * from "./auth.js";
 export * from "./clinic.js";
 export * from "./staff.js";
 export * from "./audit.js";
+export * from "./patient.js";
 
 export type PaymentIntent = {
   id: string;

--- a/packages/types/src/patient.ts
+++ b/packages/types/src/patient.ts
@@ -18,6 +18,8 @@ export type Patient = {
   status: PatientStatus;
   createdAt: string;
   updatedAt: string;
+  /** ISO-8601 timestamp; set automatically when status transitions to 'archived'. */
+  archivedAt?: string;
 };
 
 export type CreatePatientRequest = {
@@ -46,6 +48,14 @@ export type PatientListItem = Pick<
   | "familyName"
   | "status"
 >;
+
+/** A page of patients returned by paginated list endpoints. */
+export type PatientListPage = {
+  items: PatientListItem[];
+  total: number;
+  limit: number;
+  offset: number;
+};
 
 // ── Errors ────────────────────────────────────────────────────────────────────
 

--- a/packages/types/src/patient.ts
+++ b/packages/types/src/patient.ts
@@ -1,0 +1,61 @@
+// Patient master record types — Sprint 2 / Stellar Wave: patient identity.
+// Foundation issue: data model. Closes #610.
+
+export type PatientStatus = "active" | "inactive" | "archived";
+
+export type Patient = {
+  patientId: string;
+  clinicId: string;
+  /** External / clinical identifier (e.g. medical record number). Unique per clinic. */
+  identifier: string;
+  givenName: string;
+  familyName: string;
+  /** ISO-8601 date (YYYY-MM-DD). */
+  birthDate: string;
+  phone: string;
+  email: string;
+  address: string;
+  status: PatientStatus;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type CreatePatientRequest = {
+  identifier: string;
+  givenName: string;
+  familyName: string;
+  birthDate: string;
+  phone: string;
+  email: string;
+  address: string;
+};
+
+export type UpdatePatientRequest = Partial<
+  Pick<
+    Patient,
+    "givenName" | "familyName" | "phone" | "email" | "address" | "status"
+  >
+>;
+
+export type PatientListItem = Pick<
+  Patient,
+  | "patientId"
+  | "clinicId"
+  | "identifier"
+  | "givenName"
+  | "familyName"
+  | "status"
+>;
+
+// ── Errors ────────────────────────────────────────────────────────────────────
+
+export type PatientErrorCode =
+  | "PATIENT_NOT_FOUND"
+  | "PATIENT_IDENTIFIER_TAKEN"
+  | "PATIENT_ACCESS_DENIED"
+  | "PATIENT_INVALID_INPUT";
+
+export type PatientError = {
+  error: PatientErrorCode;
+  message: string;
+};


### PR DESCRIPTION
Closes #622
Closes #623 
Closes #624 
Closes #625 

Implements the HTTP boundary for the patient records foundation on top of the service layer (#738) and the data-model extensions (#737), which themselves stack on the patient identity foundation (#610).

This PR is the API surface that #626 (web) will consume.

## Endpoints (mounted at `/api/v1/patients`)

| Method | Path                              | Description                                  |
|--------|-----------------------------------|----------------------------------------------|
| POST   | `/api/v1/patients`                | Create a patient in caller's clinic          |
| GET    | `/api/v1/patients`                | Listing (paginated, sanitized PatientListPage) |
| GET    | `/api/v1/patients/:patientId`     | Read a patient                               |
| PATCH  | `/api/v1/patients/:patientId`     | Update mutable fields                        |
| DELETE | `/api/v1/patients/:patientId`     | Archive (soft-delete) — owner/admin only     |

## Role-gating matrix

Routes use `requirePermission("patient:read" / "patient:write")` from `shared/middleware/role-guard.ts`. Archive adds an inline owner/admin role check on top of `patient:write`.

| Role      | Create | List  | Read  | Update | Archive        |
|-----------|--------|-------|-------|--------|----------------|
| owner     | ✓      | ✓     | ✓     | ✓      | ✓              |
| admin     | ✓      | ✓     | ✓     | ✓      | ✓              |
| clinician | ✓      | ✓     | ✓     | ✓      | ✗ (403, inline) |
| cashier   | ✗ (403, route permission) | ✗ (403) | ✗ (403) | ✗ (403) | ✗ (403) |
| no token  | ✗ (401, resolveAuthContext) | ✗ (401) | ✗ (401) | ✗ (401) | ✗ (401) |

Inline archive restriction: clinician/cashier are blocked at the controller; the route-level permission alone would have permitted `clinician`. Documented inline in `patient.controller.ts` to prevent a future contributor from "fixing" the asymmetry.

## Error envelope notes (for #626 web)

Asymmetric by design — domain-level PatientError envelope on collision surfaces an exact PatientErrorCode that the web client must match uniquely:

| Status | Trigger                | Envelope                                                            |
|--------|------------------------|---------------------------------------------------------------------|
| 400    | validation             | `{ error: "PATIENT_INVALID_INPUT", message, field }`                |
| 401    | no auth                | `{ error: "AUTH_UNAUTHENTICATED", message }` (from resolveAuthContext) |
| 403    | permission/role block  | `{ error: "AUTH_FORBIDDEN", message }`                              |
| 404    | not-found or cross-clinic | `{ error: "PATIENT_NOT_FOUND", message }` (cross-clinic surfaces as 404, not 403, to prevent ID enumeration) |
| 409    | identifier conflict    | `{ error: <PatientErrorCode>, message }` per package-level PatientError (e.g. PATIENT_IDENTIFIER_TAKEN) |

## Clinic isolation

No `requireClinicScope` middleware — clinicId lives in the JWT (req.auth.clinicId), not the URL. The service layer enforces cross-clinic returns null -> 404, avoiding ID-enumeration leakage.

## Files added/modified (this PR)

- apps/api/src/modules/patient/controllers/patient.controller.ts - create / list / get / update / archive controllers.
- apps/api/src/modules/patient/routes/index.ts - five routes; each protected by resolveAuthContext + requirePermission.
- apps/api/src/modules/patient/tests/patient.controller.test.ts - supertest-backed integration tests covering the role matrix, envelope shapes, and cross-clinic 404.
- apps/api/src/app.ts - wires registerPatientRoutes(app) alongside existing module mounts.

## Validation

- typecheck rc=0
- eslint rc=0
- vitest 264/264 tests pass, 25 files
