### PR TITLE
feat(#713): add PatientDocument entity with data model for documents and attachments

### DIFF
--- a/apps/api/src/modules/patient-documents/dto/create-patient-document.dto.ts
+++ b/apps/api/src/modules/patient-documents/dto/create-patient-document.dto.ts
@@ -1,0 +1,37 @@
+import { IsEnum, IsNotEmpty, IsNumber, IsOptional, IsString, IsUUID, MaxLength } from 'class-validator';
+import { DocumentType } from '../entities/patient-document.entity';
+
+export class CreatePatientDocumentDto {
+  @IsUUID()
+  @IsNotEmpty()
+  patientId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(255)
+  fileName: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(512)
+  fileUrl: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  mimeType: string;
+
+  @IsNumber()
+  fileSizeBytes: number;
+
+  @IsEnum(DocumentType)
+  @IsOptional()
+  documentType?: DocumentType;
+
+  @IsString()
+  @IsOptional()
+  description?: string;
+
+  @IsOptional()
+  metadata?: Record<string, unknown>;
+}

--- a/apps/api/src/modules/patient-documents/entities/patient-document.entity.ts
+++ b/apps/api/src/modules/patient-documents/entities/patient-document.entity.ts
@@ -1,0 +1,67 @@
+import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn, ManyToOne, JoinColumn } from 'typeorm';
+
+export enum DocumentType {
+  LAB_RESULT    = 'lab_result',
+  PRESCRIPTION  = 'prescription',
+  IMAGING       = 'imaging',
+  DISCHARGE     = 'discharge_summary',
+  CONSENT_FORM  = 'consent_form',
+  OTHER         = 'other',
+}
+
+export enum DocumentStatus {
+  PENDING   = 'pending',
+  ACTIVE    = 'active',
+  REVOKED   = 'revoked',
+  ARCHIVED  = 'archived',
+}
+
+@Entity('patient_documents')
+export class PatientDocument {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  patientId: string;
+
+  @Column({ type: 'uuid', nullable: true })
+  uploadedBy?: string;
+
+  @Column({ type: 'varchar', length: 255 })
+  fileName: string;
+
+  @Column({ type: 'varchar', length: 512 })
+  fileUrl: string;
+
+  @Column({ type: 'varchar', length: 100 })
+  mimeType: string;
+
+  @Column({ type: 'int' })
+  fileSizeBytes: number;
+
+  @Column({
+    type: 'enum',
+    enum: DocumentType,
+    default: DocumentType.OTHER,
+  })
+  documentType: DocumentType;
+
+  @Column({
+    type: 'enum',
+    enum: DocumentStatus,
+    default: DocumentStatus.ACTIVE,
+  })
+  status: DocumentStatus;
+
+  @Column({ type: 'text', nullable: true })
+  description?: string;
+
+  @Column({ type: 'jsonb', nullable: true })
+  metadata?: Record<string, unknown>;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}


### PR DESCRIPTION
Fixes #713

Adds TypeORM entity with DocumentType/DocumentStatus enums and CreatePatientDocumentDto with class-validator decorators. Covers data model scope for the patient documents sprint.

ETH 0xeaCAb48a4bfA0CED0e668c166615927115655594 | SOL C3MD2yfWYebB8FYXpq6ooqzU5GCQB1bDxbDhQf1JfiCW