### PR TITLE
feat(#688): add Consent entity data model for patient consent and privacy

### DIFF
--- a/apps/api/src/modules/consent/entities/consent.entity.ts
+++ b/apps/api/src/modules/consent/entities/consent.entity.ts
@@ -1,0 +1,55 @@
+import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+
+export enum ConsentType {
+  TREATMENT       = 'treatment',
+  DATA_SHARING    = 'data_sharing',
+  RESEARCH        = 'research',
+  MARKETING       = 'marketing',
+  TELEMEDICINE    = 'telemedicine',
+}
+
+export enum ConsentStatus {
+  GRANTED   = 'granted',
+  REVOKED   = 'revoked',
+  EXPIRED   = 'expired',
+  PENDING   = 'pending',
+}
+
+@Entity('consents')
+export class Consent {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  patientId: string;
+
+  @Column({ type: 'uuid', nullable: true })
+  grantedTo?: string;  // clinician or org that received consent
+
+  @Column({ type: 'enum', enum: ConsentType })
+  consentType: ConsentType;
+
+  @Column({ type: 'enum', enum: ConsentStatus, default: ConsentStatus.PENDING })
+  status: ConsentStatus;
+
+  @Column({ type: 'timestamp', nullable: true })
+  grantedAt?: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  revokedAt?: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  expiresAt?: Date;
+
+  @Column({ type: 'text', nullable: true })
+  notes?: string;
+
+  @Column({ type: 'varchar', length: 45, nullable: true })
+  ipAddress?: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}


### PR DESCRIPTION
Fixes #688

Adds Consent TypeORM entity with ConsentType/ConsentStatus enums. Tracks patientId, grantedTo, grantedAt, revokedAt, expiresAt, ipAddress.

ETH 0xeaCAb48a4bfA0CED0e668c166615927115655594 | SOL C3MD2yfWYebB8FYXpq6ooqzU5GCQB1bDxbDhQf1JfiCW