### PR TITLE
feat(#730): add PatientDocumentsController with full REST API

### DIFF
--- a/apps/api/src/modules/patient-documents/patient-documents.controller.ts
+++ b/apps/api/src/modules/patient-documents/patient-documents.controller.ts
@@ -1,0 +1,38 @@
+import { Controller, Get, Post, Patch, Delete, Param, Body, Req, UseGuards, ParseUUIDPipe, HttpCode, HttpStatus } from '@nestjs/common';
+import { PatientDocumentsService } from './patient-documents.service';
+import { CreatePatientDocumentDto } from './dto/create-patient-document.dto';
+
+@Controller('patients/:patientId/documents')
+export class PatientDocumentsController {
+  constructor(private readonly svc: PatientDocumentsService) {}
+
+  @Post()
+  create(
+    @Param('patientId', ParseUUIDPipe) patientId: string,
+    @Body() dto: CreatePatientDocumentDto,
+  ) {
+    return this.svc.create({ ...dto, patientId });
+  }
+
+  @Get()
+  findAll(@Param('patientId', ParseUUIDPipe) patientId: string) {
+    return this.svc.findAllByPatient(patientId);
+  }
+
+  @Get(':id')
+  findOne(@Param('id', ParseUUIDPipe) id: string) {
+    return this.svc.findOne(id);
+  }
+
+  @Patch(':id/revoke')
+  @HttpCode(HttpStatus.OK)
+  revoke(@Param('id', ParseUUIDPipe) id: string) {
+    return this.svc.revoke(id);
+  }
+
+  @Patch(':id/archive')
+  @HttpCode(HttpStatus.OK)
+  archive(@Param('id', ParseUUIDPipe) id: string) {
+    return this.svc.archive(id);
+  }
+}


### PR DESCRIPTION
Fixes #730

Adds NestJS controller with POST/GET/GET:id/PATCH:id/revoke/PATCH:id/archive endpoints. ParseUUIDPipe on all params.

ETH 0xeaCAb48a4bfA0CED0e668c166615927115655594 | SOL C3MD2yfWYebB8FYXpq6ooqzU5GCQB1bDxbDhQf1JfiCW