### PR TITLE
test(#724): add QueryDocumentsDto validation tests

### DIFF
--- a/apps/api/src/modules/patient-documents/query-documents.dto.spec.ts
+++ b/apps/api/src/modules/patient-documents/query-documents.dto.spec.ts
@@ -1,0 +1,18 @@
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { QueryDocumentsDto } from './dto/query-documents.dto';
+import { DocumentStatus, DocumentType } from './entities/patient-document.entity';
+
+async function v(plain: object) {
+  return validate(plainToInstance(QueryDocumentsDto, plain));
+}
+
+describe('QueryDocumentsDto', () => {
+  it('valid empty object passes', async () => expect(await v({})).toHaveLength(0));
+  it('valid status passes', async () => expect(await v({ status: DocumentStatus.ACTIVE })).toHaveLength(0));
+  it('invalid status fails', async () => expect(await v({ status: 'bad' })).toHaveLength(1));
+  it('valid limit passes', async () => expect(await v({ limit: 50 })).toHaveLength(0));
+  it('limit over 200 fails', async () => expect(await v({ limit: 201 })).toHaveLength(1));
+  it('negative offset fails', async () => expect(await v({ offset: -1 })).toHaveLength(1));
+  it('valid documentType passes', async () => expect(await v({ documentType: DocumentType.LAB_RESULT })).toHaveLength(0));
+});


### PR DESCRIPTION
Fixes #724

7 tests: valid empty, valid status, invalid status, valid limit, limit>200, negative offset, valid type.

ETH 0xeaCAb48a4bfA0CED0e668c166615927115655594 | SOL C3MD2yfWYebB8FYXpq6ooqzU5GCQB1bDxbDhQf1JfiCW