### PR TITLE
feat(#725): add filtered documents controller with search and stats

### DIFF
--- a/apps/api/src/modules/patient-documents/patient-documents-filtered.controller.ts
+++ b/apps/api/src/modules/patient-documents/patient-documents-filtered.controller.ts
@@ -1,0 +1,28 @@
+import { Controller, Get, Param, Query, ParseUUIDPipe } from '@nestjs/common';
+import { PatientDocumentsQueryService, DocumentQueryOptions } from './patient-documents-v2.service';
+import { QueryDocumentsDto } from './dto/query-documents.dto';
+
+@Controller('patients/:patientId/documents')
+export class PatientDocumentsFilteredController {
+  constructor(private readonly svc: PatientDocumentsQueryService) {}
+
+  @Get('search')
+  search(
+    @Param('patientId', ParseUUIDPipe) patientId: string,
+    @Query() query: QueryDocumentsDto,
+  ) {
+    const opts: DocumentQueryOptions = {
+      status:       query.status,
+      documentType: query.documentType,
+      search:       query.search,
+      limit:        query.limit,
+      offset:       query.offset,
+    };
+    return this.svc.findWithFilters(patientId, opts);
+  }
+
+  @Get('stats')
+  stats(@Param('patientId', ParseUUIDPipe) patientId: string) {
+    return this.svc.countByStatus(patientId);
+  }
+}


### PR DESCRIPTION
Fixes #725

GET /patients/:id/documents/search with QueryDocumentsDto, GET /stats for counts.

ETH 0xeaCAb48a4bfA0CED0e668c166615927115655594 | SOL C3MD2yfWYebB8FYXpq6ooqzU5GCQB1bDxbDhQf1JfiCW