### PR TITLE
feat: patient records foundation — consent and privacy data model

### DIFF
--- a/apps/api/src/__tests__/consent-model.test.ts
+++ b/apps/api/src/__tests__/consent-model.test.ts
@@ -1,0 +1,39 @@
+import { createConsentRecord, validateConsent, createPrivacyPreference, fixtures } from "../consent/model";
+
+describe("Consent & Privacy Data Model", () => {
+  describe("validateConsent", () => {
+    it("accepts valid consent", () => {
+      expect(validateConsent(fixtures.validConsent)).toEqual([]);
+    });
+
+    it("rejects invalid consent", () => {
+      const errors = validateConsent(fixtures.invalidConsent);
+      expect(errors).toContain("Valid consentType is required");
+      expect(errors).toContain("scope is required");
+    });
+  });
+
+  describe("createConsentRecord", () => {
+    it("creates a granted consent record", () => {
+      const record = createConsentRecord(fixtures.patientId, fixtures.clinicId, fixtures.validConsent);
+      expect(record.status).toBe("granted");
+      expect(record.consentType).toBe("data-sharing");
+      expect(record.patientId).toBe("pat_cns_01");
+      expect(record.id).toMatch(/^cns_/);
+    });
+
+    it("sets null for missing expiresAt", () => {
+      const record = createConsentRecord(fixtures.patientId, fixtures.clinicId, { consentType: "research", scope: "anonymized data only" });
+      expect(record.expiresAt).toBeNull();
+    });
+  });
+
+  describe("createPrivacyPreference", () => {
+    it("creates defaults", () => {
+      const pref = createPrivacyPreference("pat_privacy_01");
+      expect(pref.shareWithProvider).toBe(true);
+      expect(pref.shareForResearch).toBe(false);
+      expect(pref.dataRetentionDays).toBe(365);
+    });
+  });
+});

--- a/apps/api/src/consent/model.ts
+++ b/apps/api/src/consent/model.ts
@@ -1,0 +1,82 @@
+export type ConsentStatus = "granted" | "revoked" | "expired";
+
+export type ConsentType = "data-sharing" | "marketing" | "research" | "third-party" | "emergency-contact";
+
+export type ConsentRecord = {
+  id: string;
+  patientId: string;
+  clinicId: string;
+  consentType: ConsentType;
+  status: ConsentStatus;
+  grantedAt: string;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  scope: string;
+  notes: string;
+};
+
+export type PrivacyPreference = {
+  patientId: string;
+  shareWithProvider: boolean;
+  shareWithInsurer: boolean;
+  shareForResearch: boolean;
+  allowEmergencyAccess: boolean;
+  dataRetentionDays: number;
+  updatedAt: string;
+};
+
+export type ConsentAuditEntry = {
+  id: string;
+  patientId: string;
+  consentId: string;
+  action: "grant" | "revoke" | "expire" | "update";
+  performedBy: string;
+  timestamp: string;
+  details: string;
+};
+
+const defaultPrivacy: Omit<PrivacyPreference, "patientId" | "updatedAt"> = {
+  shareWithProvider: true,
+  shareWithInsurer: true,
+  shareForResearch: false,
+  allowEmergencyAccess: true,
+  dataRetentionDays: 365,
+};
+
+export function createPrivacyPreference(patientId: string): PrivacyPreference {
+  return { patientId, ...defaultPrivacy, updatedAt: new Date().toISOString() };
+}
+
+export function validateConsent(payload: Record<string, unknown>): string[] {
+  const errors: string[] = [];
+  if (!payload.consentType || !["data-sharing", "marketing", "research", "third-party", "emergency-contact"].includes(payload.consentType as string))
+    errors.push("Valid consentType is required");
+  if (!payload.scope || typeof payload.scope !== "string") errors.push("scope is required");
+  return errors;
+}
+
+export function createConsentRecord(
+  patientId: string,
+  clinicId: string,
+  data: { consentType: ConsentType; scope: string; expiresAt?: string; notes?: string },
+): ConsentRecord {
+  return {
+    id: `cns_${Date.now()}`,
+    patientId,
+    clinicId,
+    consentType: data.consentType,
+    status: "granted",
+    grantedAt: new Date().toISOString(),
+    expiresAt: data.expiresAt || null,
+    revokedAt: null,
+    scope: data.scope,
+    notes: data.notes || "",
+  };
+}
+
+export const fixtures = {
+  validConsent: { consentType: "data-sharing" as ConsentType, scope: "share vitals with primary care", expiresAt: "2027-01-01T00:00:00Z", notes: "Annual consent" },
+  invalidConsent: { consentType: "invalid-type", scope: "" },
+  patientId: "pat_cns_01",
+  clinicId: "clinic_cns_01",
+};

--- a/apps/stellar-service/src/consent/model.ts
+++ b/apps/stellar-service/src/consent/model.ts
@@ -1,0 +1,54 @@
+import {
+  Keypair,
+  TransactionBuilder,
+  Operation,
+  BASE_FEE,
+  Networks,
+  Memo,
+} from "@stellar/stellar-sdk";
+
+export type ConsentData = {
+  patientId: string;
+  consentType: string;
+  status: string;
+  grantedAt: string;
+  expiresAt: string;
+};
+
+function serialize(data: ConsentData): string {
+  return `${data.patientId}|${data.consentType}|${data.status}|${data.grantedAt}|${data.expiresAt}`;
+}
+
+export function hashConsent(data: ConsentData): string {
+  const bytes = new TextEncoder().encode(serialize(data));
+  return Array.from(bytes).map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+export function buildConsentTx(
+  source: Keypair,
+  data: ConsentData,
+  network: string = Networks.TESTNET,
+) {
+  const h = hashConsent(data);
+  const key = `cns_${data.patientId.slice(0, 8)}`;
+  return new TransactionBuilder(source, { fee: BASE_FEE, networkPassphrase: network })
+    .addOperation(Operation.manageData({ source: source.publicKey(), name: key, value: h }))
+    .addOperation(Operation.manageData({ source: source.publicKey(), name: `${key}_type`, value: data.consentType }))
+    .addMemo(Memo.text("consent-model"))
+    .setTimeout(30)
+    .build();
+}
+
+export function verifyConsent(expected: ConsentData, storedHash: string): boolean {
+  return hashConsent(expected) === storedHash;
+}
+
+export function parseConsentValue(value: string): ConsentData {
+  const [patientId, consentType, status, grantedAt, expiresAt] = value.split("|");
+  return { patientId, consentType, status, grantedAt, expiresAt };
+}
+
+export const fixtures = {
+  source: Keypair.fromRawEd25519Seed(Buffer.alloc(32, 10)),
+  data: { patientId: "pat_cns_st_01", consentType: "data-sharing", status: "granted", grantedAt: "2026-06-01T00:00:00Z", expiresAt: "2027-06-01T00:00:00Z" } satisfies ConsentData,
+};

--- a/apps/web/lib/consent.ts
+++ b/apps/web/lib/consent.ts
@@ -1,0 +1,46 @@
+export type ConsentStatus = "granted" | "revoked" | "expired";
+
+export type ConsentRecord = {
+  id: string;
+  consentType: string;
+  status: ConsentStatus;
+  grantedAt: string;
+  expiresAt: string | null;
+  scope: string;
+};
+
+export type PrivacySettings = {
+  shareWithProvider: boolean;
+  shareWithInsurer: boolean;
+  shareForResearch: boolean;
+  allowEmergencyAccess: boolean;
+  dataRetentionDays: number;
+};
+
+export function formatConsentSummary(record: ConsentRecord): string {
+  const expiry = record.expiresAt ? `expires ${new Date(record.expiresAt).toLocaleDateString()}` : "no expiry";
+  return `${record.consentType}: ${record.status} (${expiry}) — ${record.scope}`;
+}
+
+export function isConsentActive(record: ConsentRecord): boolean {
+  if (record.status !== "granted") return false;
+  if (record.expiresAt && new Date(record.expiresAt) < new Date()) return false;
+  return true;
+}
+
+export function defaultPrivacySettings(): PrivacySettings {
+  return { shareWithProvider: true, shareWithInsurer: true, shareForResearch: false, allowEmergencyAccess: true, dataRetentionDays: 365 };
+}
+
+export function validatePrivacySettings(s: Partial<PrivacySettings>): string[] {
+  const e: string[] = [];
+  if (s.dataRetentionDays !== undefined && (s.dataRetentionDays < 30 || s.dataRetentionDays > 3650))
+    e.push("dataRetentionDays must be between 30 and 3650");
+  return e;
+}
+
+export const fixtures = {
+  activeConsent: { id: "cns_01", consentType: "data-sharing", status: "granted" as ConsentStatus, grantedAt: "2026-01-01T00:00:00Z", expiresAt: "2027-01-01T00:00:00Z", scope: "vitals" },
+  expiredConsent: { id: "cns_02", consentType: "marketing", status: "granted" as ConsentStatus, grantedAt: "2025-01-01T00:00:00Z", expiresAt: "2025-06-01T00:00:00Z", scope: "email" },
+  revokedConsent: { id: "cns_03", consentType: "research", status: "revoked" as ConsentStatus, grantedAt: "2026-01-01T00:00:00Z", expiresAt: null, scope: "genetic data" },
+};


### PR DESCRIPTION
### Sprint: Patient records foundation

- **api** (#685): `apps/api/src/consent/model.ts` — consent/privacy data model, validation, defaults
- **web** (#686): `apps/web/lib/consent.ts` — consent formatting, active check, privacy settings
- **stellar** (#688): `apps/stellar-service/src/consent/model.ts` — on-chain consent hash/verify/parse
- **test** (#689): `apps/api/src/__tests__/consent-model.test.ts` — data model tests

Closes #685
Closes #686
Closes #688
Closes #689