### PR TITLE
feat: patient records foundation — consent and privacy service layer

### DIFF
--- a/apps/api/src/consent/service.ts
+++ b/apps/api/src/consent/service.ts
@@ -1,0 +1,81 @@
+export type ConsentStatus = "granted" | "revoked" | "expired";
+
+export type ConsentRecord = {
+  id: string;
+  patientId: string;
+  clinicId: string;
+  consentType: string;
+  status: ConsentStatus;
+  grantedAt: string;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  scope: string;
+  notes: string;
+};
+
+export type ServiceResult<T> = { ok: true; data: T } | { ok: false; error: string };
+
+const store = new Map<string, ConsentRecord[]>();
+let counter = 0;
+
+function ensure(pid: string): ConsentRecord[] {
+  if (!store.has(pid)) store.set(pid, []);
+  return store.get(pid)!;
+}
+
+export function createConsentService() {
+  function grant(patientId: string, clinicId: string, data: { consentType: string; scope: string; expiresAt?: string; notes?: string }): ServiceResult<ConsentRecord> {
+    if (!data.consentType || !data.scope) return { ok: false, error: "consentType and scope required" };
+    counter++;
+    const record: ConsentRecord = {
+      id: `cns_svc_${counter}`,
+      patientId,
+      clinicId,
+      consentType: data.consentType,
+      status: "granted",
+      grantedAt: new Date().toISOString(),
+      expiresAt: data.expiresAt || null,
+      revokedAt: null,
+      scope: data.scope,
+      notes: data.notes || "",
+    };
+    ensure(patientId).push(record);
+    return { ok: true, data: record };
+  }
+
+  function revoke(patientId: string, consentId: string): ServiceResult<ConsentRecord> {
+    const entries = ensure(patientId);
+    const record = entries.find((e) => e.id === consentId);
+    if (!record) return { ok: false, error: "NOT_FOUND" };
+    if (record.status !== "granted") return { ok: false, error: "CANNOT_REVOKE" };
+    record.status = "revoked";
+    record.revokedAt = new Date().toISOString();
+    return { ok: true, data: record };
+  }
+
+  function listActive(patientId: string): ServiceResult<ConsentRecord[]> {
+    const entries = ensure(patientId);
+    const active = entries.filter((e) => {
+      if (e.status !== "granted") return false;
+      if (e.expiresAt && new Date(e.expiresAt) < new Date()) return false;
+      return true;
+    });
+    return { ok: true, data: active };
+  }
+
+  function getHistory(patientId: string): ServiceResult<ConsentRecord[]> {
+    const entries = store.get(patientId);
+    if (!entries || entries.length === 0) return { ok: false, error: "NOT_FOUND" };
+    return { ok: true, data: [...entries].sort((a, b) => b.grantedAt.localeCompare(a.grantedAt)) };
+  }
+
+  function reset() { store.clear(); counter = 0; }
+
+  return { grant, revoke, listActive, getHistory, reset };
+}
+
+export const fixtures = {
+  validGrant: { consentType: "data-sharing", scope: "share vitals with provider", notes: "Standard" },
+  patientId: "pat_svc_cns_01",
+  clinicId: "clinic_svc_01",
+};

--- a/apps/mobile/src/services/consent.ts
+++ b/apps/mobile/src/services/consent.ts
@@ -1,0 +1,45 @@
+export type ConsentRecord = {
+  id: string;
+  consentType: string;
+  status: string;
+  scope: string;
+  grantedAt: string;
+  expiresAt: string | null;
+};
+
+export type MobileServiceResult<T> =
+  | { type: "success"; data: T }
+  | { type: "error"; message: string };
+
+const BASE_PATH = "/api/v1/patients";
+
+export function createMobileConsentService(baseUrl: string) {
+  async function request<T>(method: string, patientId: string, clinicId: string, body?: unknown): Promise<MobileServiceResult<T>> {
+    try {
+      const res = await fetch(`${baseUrl}${BASE_PATH}/${encodeURIComponent(patientId)}/consent`, {
+        method,
+        headers: { "content-type": "application/json", "x-clinic-id": clinicId },
+        body: body ? JSON.stringify(body) : undefined,
+      });
+      const data = await res.json();
+      if (!res.ok) return { type: "error", message: data.error || `HTTP ${res.status}` };
+      return { type: "success", data: data as T };
+    } catch (e) {
+      return { type: "error", message: e instanceof Error ? e.message : "Network error" };
+    }
+  }
+
+  function grant(patientId: string, payload: { consentType: string; scope: string; expiresAt?: string }) {
+    return request<ConsentRecord>("POST", patientId, "default", payload);
+  }
+
+  function revoke(patientId: string, consentId: string) {
+    return request<ConsentRecord>("POST", patientId, "default", { action: "revoke", consentId });
+  }
+
+  function getActive(patientId: string) {
+    return request<ConsentRecord[]>("GET", patientId, "default");
+  }
+
+  return { grant, revoke, getActive };
+}

--- a/apps/stellar-service/src/consent/service.ts
+++ b/apps/stellar-service/src/consent/service.ts
@@ -1,0 +1,48 @@
+import {
+  Keypair,
+  TransactionBuilder,
+  Operation,
+  BASE_FEE,
+  Networks,
+  Memo,
+} from "@stellar/stellar-sdk";
+
+export type ConsentServiceData = {
+  patientId: string;
+  consentType: string;
+  status: string;
+  scope: string;
+  timestamp: string;
+};
+
+function serialize(data: ConsentServiceData): string {
+  return `${data.patientId}|${data.consentType}|${data.status}|${data.scope}|${data.timestamp}`;
+}
+
+export function hashServiceConsent(data: ConsentServiceData): string {
+  const bytes = new TextEncoder().encode(serialize(data));
+  return Array.from(bytes).map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+export function buildServiceConsentTx(
+  source: Keypair,
+  data: ConsentServiceData,
+  network: string = Networks.TESTNET,
+) {
+  const h = hashServiceConsent(data);
+  const key = `cns_svc_${data.patientId.slice(0, 8)}`;
+  return new TransactionBuilder(source, { fee: BASE_FEE, networkPassphrase: network })
+    .addOperation(Operation.manageData({ source: source.publicKey(), name: key, value: h }))
+    .addMemo(Memo.text("consent-svc"))
+    .setTimeout(30)
+    .build();
+}
+
+export function verifyServiceConsent(expected: ConsentServiceData, storedHash: string): boolean {
+  return hashServiceConsent(expected) === storedHash;
+}
+
+export const fixtures = {
+  source: Keypair.fromRawEd25519Seed(Buffer.alloc(32, 11)),
+  data: { patientId: "pat_cns_svc_01", consentType: "data-sharing", status: "granted", scope: "share vitals", timestamp: "2026-06-15T10:00:00Z" } satisfies ConsentServiceData,
+};

--- a/apps/web/lib/consent-service.ts
+++ b/apps/web/lib/consent-service.ts
@@ -1,0 +1,47 @@
+export type ConsentRecord = {
+  id: string;
+  consentType: string;
+  status: string;
+  scope: string;
+  grantedAt: string;
+  expiresAt: string | null;
+};
+
+export type ConsentServiceResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; error: string };
+
+const API_BASE = "/api/v1";
+
+export function createWebConsentService(baseUrl: string) {
+  const api = baseUrl || process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000";
+
+  async function request<T>(method: string, patientId: string, clinicId: string, body?: unknown): Promise<ConsentServiceResult<T>> {
+    try {
+      const res = await fetch(`${api}${API_BASE}/patients/${patientId}/consent`, {
+        method,
+        headers: { "content-type": "application/json", "x-clinic-id": clinicId },
+        body: body ? JSON.stringify(body) : undefined,
+      });
+      const data = await res.json();
+      if (!res.ok) return { ok: false, error: data.error || `HTTP ${res.status}` };
+      return { ok: true, data: data as T };
+    } catch (e) {
+      return { ok: false, error: e instanceof Error ? e.message : "Network error" };
+    }
+  }
+
+  function grant(patientId: string, clinicId: string, payload: { consentType: string; scope: string; expiresAt?: string }) {
+    return request<ConsentRecord>("POST", patientId, clinicId, payload);
+  }
+
+  function revoke(patientId: string, clinicId: string, consentId: string) {
+    return request<ConsentRecord>("POST", patientId, clinicId, { action: "revoke", consentId });
+  }
+
+  function listActive(patientId: string, clinicId: string) {
+    return request<ConsentRecord[]>("GET", patientId, clinicId);
+  }
+
+  return { grant, revoke, listActive };
+}


### PR DESCRIPTION
### Sprint: Patient records foundation

- **api** (#690): `apps/api/src/consent/service.ts` — consent CRUD with grant/revoke/listActive/getHistory
- **web** (#691): `apps/web/lib/consent-service.ts` — fetch-based consent API client
- **mobile** (#692): `apps/mobile/src/services/consent.ts` — mobile consent service client
- **stellar** (#693): `apps/stellar-service/src/consent/service.ts` — on-chain consent hash/verify

Closes #690
Closes #691
Closes #692
Closes #693