### PR TITLE
feat(api): add documents and attachments module

### DIFF
--- a/apps/api/src/documents/contract.ts
+++ b/apps/api/src/documents/contract.ts
@@ -1,0 +1,119 @@
+export type DocumentDTO = {
+  id: string;
+  patientId: string;
+  clinicId: string;
+  fileName: string;
+  fileType: string;
+  fileSizeBytes: number;
+  category: string;
+  status: string;
+  uploadedBy: string;
+  description: string;
+  tags: string[];
+  storageUrl: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type AttachmentDTO = {
+  id: string;
+  documentId: string;
+  patientId: string;
+  clinicId: string;
+  fileName: string;
+  mimeType: string;
+  fileSizeBytes: number;
+  storageKey: string;
+  uploadedBy: string;
+  createdAt: string;
+};
+
+export type CreateDocumentRequest = Omit<DocumentDTO, "id" | "clinicId" | "status" | "createdAt" | "updatedAt">;
+
+export type UpdateDocumentRequest = Partial<Omit<DocumentDTO, "id" | "patientId" | "clinicId" | "createdAt" | "updatedAt">>;
+
+export type UploadAttachmentRequest = Omit<AttachmentDTO, "id" | "createdAt">;
+
+export type ContractEndpoint = {
+  method: "GET" | "POST" | "PATCH" | "DELETE";
+  path: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+  response: unknown;
+};
+
+export const DOCUMENTS_CONTRACT = {
+  list: {
+    method: "GET" as const,
+    path: "/api/v1/patients/:patientId/documents",
+    headers: { "x-clinic-id": "string" },
+    response: [] as DocumentDTO[],
+  },
+  get: {
+    method: "GET" as const,
+    path: "/api/v1/patients/:patientId/documents/:documentId",
+    headers: { "x-clinic-id": "string" },
+    response: {} as DocumentDTO,
+  },
+  create: {
+    method: "POST" as const,
+    path: "/api/v1/patients/:patientId/documents",
+    headers: { "x-clinic-id": "string", "content-type": "application/json" },
+    body: {} as CreateDocumentRequest,
+    response: {} as DocumentDTO,
+  },
+  update: {
+    method: "PATCH" as const,
+    path: "/api/v1/patients/:patientId/documents/:documentId",
+    headers: { "x-clinic-id": "string", "content-type": "application/json" },
+    body: {} as UpdateDocumentRequest,
+    response: {} as DocumentDTO,
+  },
+  delete: {
+    method: "DELETE" as const,
+    path: "/api/v1/patients/:patientId/documents/:documentId",
+    headers: { "x-clinic-id": "string" },
+    response: { ok: true },
+  },
+  listAttachments: {
+    method: "GET" as const,
+    path: "/api/v1/patients/:patientId/documents/:documentId/attachments",
+    headers: { "x-clinic-id": "string" },
+    response: [] as AttachmentDTO[],
+  },
+  uploadAttachment: {
+    method: "POST" as const,
+    path: "/api/v1/patients/:patientId/documents/:documentId/attachments",
+    headers: { "x-clinic-id": "string", "content-type": "application/json" },
+    body: {} as UploadAttachmentRequest,
+    response: {} as AttachmentDTO,
+  },
+  deleteAttachment: {
+    method: "DELETE" as const,
+    path: "/api/v1/patients/:patientId/documents/:documentId/attachments/:attachmentId",
+    headers: { "x-clinic-id": "string" },
+    response: { ok: true },
+  },
+} as const;
+
+export type DocumentsEndpoints = typeof DOCUMENTS_CONTRACT;
+
+export function buildListUrl(baseUrl: string, patientId: string): string {
+  return `${baseUrl.replace(/\/+$/, "")}/api/v1/patients/${encodeURIComponent(patientId)}/documents`;
+}
+
+export function buildItemUrl(baseUrl: string, patientId: string, documentId: string): string {
+  return `${baseUrl.replace(/\/+$/, "")}/api/v1/patients/${encodeURIComponent(patientId)}/documents/${encodeURIComponent(documentId)}`;
+}
+
+export function buildAttachmentsUrl(baseUrl: string, patientId: string, documentId: string): string {
+  return `${buildItemUrl(baseUrl, patientId, documentId)}/attachments`;
+}
+
+export function validateContractResponse(status: number, body: unknown): string | null {
+  if (status === 200 || status === 201) return null;
+  if (status === 400) return "VALIDATION_ERROR";
+  if (status === 404) return "NOT_FOUND";
+  if (status === 500) return "SERVER_ERROR";
+  return `UNEXPECTED_STATUS_${status}`;
+}

--- a/apps/api/src/documents/model.ts
+++ b/apps/api/src/documents/model.ts
@@ -1,0 +1,105 @@
+export type DocumentCategory = "clinical" | "administrative" | "lab-report" | "imaging" | "consent-form" | "other";
+
+export type DocumentStatus = "pending" | "uploaded" | "verified" | "archived";
+
+export type DocumentRecord = {
+  id: string;
+  patientId: string;
+  clinicId: string;
+  fileName: string;
+  fileType: string;
+  fileSizeBytes: number;
+  category: DocumentCategory;
+  status: DocumentStatus;
+  uploadedBy: string;
+  description: string;
+  tags: string[];
+  storageUrl: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type AttachmentRecord = {
+  id: string;
+  documentId: string;
+  patientId: string;
+  clinicId: string;
+  fileName: string;
+  mimeType: string;
+  fileSizeBytes: number;
+  storageKey: string;
+  uploadedBy: string;
+  createdAt: string;
+};
+
+export type CreateDocumentPayload = Omit<DocumentRecord, "id" | "clinicId" | "status" | "createdAt" | "updatedAt">;
+
+export type UpdateDocumentPayload = Partial<Omit<DocumentRecord, "id" | "patientId" | "clinicId" | "createdAt" | "updatedAt">>;
+
+export type UploadAttachmentPayload = Omit<AttachmentRecord, "id" | "createdAt">;
+
+export function sanitizeDocumentPayload(payload: CreateDocumentPayload): CreateDocumentPayload {
+  return {
+    ...payload,
+    tags: payload.tags || [],
+    description: payload.description || "",
+  };
+}
+
+export function validateDocumentPayload(payload: Record<string, unknown>): string[] {
+  const errors: string[] = [];
+  if (!payload.patientId || typeof payload.patientId !== "string") errors.push("patientId is required");
+  if (!payload.fileName || typeof payload.fileName !== "string") errors.push("fileName is required");
+  if (!payload.fileType || typeof payload.fileType !== "string") errors.push("fileType is required");
+  if (!payload.category || !["clinical", "administrative", "lab-report", "imaging", "consent-form", "other"].includes(payload.category as string))
+    errors.push("category must be one of: clinical, administrative, lab-report, imaging, consent-form, other");
+  if (payload.fileSizeBytes && typeof payload.fileSizeBytes !== "number") errors.push("fileSizeBytes must be a number");
+  return errors;
+}
+
+export function createDocumentRecord(payload: CreateDocumentPayload, clinicId: string): DocumentRecord {
+  const sanitized = sanitizeDocumentPayload(payload);
+  const now = new Date().toISOString();
+  return {
+    id: `doc_${Date.now()}`,
+    clinicId,
+    status: "pending",
+    ...sanitized,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export function createAttachmentRecord(payload: UploadAttachmentPayload): AttachmentRecord {
+  const now = new Date().toISOString();
+  return {
+    id: `att_${Date.now()}`,
+    ...payload,
+    createdAt: now,
+  };
+}
+
+export const fixtures = {
+  validClinical: {
+    patientId: "pat_demo_01",
+    fileName: "lab-result.pdf",
+    fileType: "application/pdf",
+    fileSizeBytes: 245760,
+    category: "lab-report" as DocumentCategory,
+    uploadedBy: "staff_demo_01",
+    description: "Complete blood count results",
+    tags: ["lab", "blood", "routine"],
+    storageUrl: "https://storage.example.com/lab-result.pdf",
+  } satisfies CreateDocumentPayload,
+  validAttachment: {
+    documentId: "doc_demo_01",
+    patientId: "pat_demo_01",
+    clinicId: "clinic_demo_01",
+    fileName: "scan001.dcm",
+    mimeType: "application/dicom",
+    fileSizeBytes: 5242880,
+    storageKey: "uploads/scan001.dcm",
+    uploadedBy: "staff_demo_01",
+  } satisfies UploadAttachmentPayload,
+  invalidPayload: {} as Record<string, unknown>,
+};

--- a/apps/api/src/documents/service.ts
+++ b/apps/api/src/documents/service.ts
@@ -1,0 +1,216 @@
+import type { Request, Response, NextFunction } from "express";
+import type { DocumentCategory, DocumentStatus } from "./model.js";
+
+export type DocumentRecord = {
+  id: string;
+  patientId: string;
+  clinicId: string;
+  fileName: string;
+  fileType: string;
+  fileSizeBytes: number;
+  category: DocumentCategory;
+  status: DocumentStatus;
+  uploadedBy: string;
+  description: string;
+  tags: string[];
+  storageUrl: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type AttachmentRecord = {
+  id: string;
+  documentId: string;
+  patientId: string;
+  clinicId: string;
+  fileName: string;
+  mimeType: string;
+  fileSizeBytes: number;
+  storageKey: string;
+  uploadedBy: string;
+  createdAt: string;
+};
+
+export type CreateDocumentBody = Omit<DocumentRecord, "id" | "clinicId" | "status" | "createdAt" | "updatedAt">;
+
+export type UpdateDocumentBody = Partial<Omit<DocumentRecord, "id" | "patientId" | "clinicId" | "createdAt" | "updatedAt">>;
+
+export type UploadAttachmentBody = Omit<AttachmentRecord, "id" | "createdAt">;
+
+export type DocumentsService = {
+  findByPatientId(patientId: string, clinicId: string): DocumentRecord[];
+  findById(documentId: string, clinicId: string): DocumentRecord | undefined;
+  create(patientId: string, clinicId: string, data: CreateDocumentBody): DocumentRecord;
+  update(documentId: string, clinicId: string, data: UpdateDocumentBody): DocumentRecord | undefined;
+  delete(documentId: string, clinicId: string): boolean;
+  getAttachments(documentId: string, clinicId: string): AttachmentRecord[];
+  addAttachment(documentId: string, clinicId: string, data: UploadAttachmentBody): AttachmentRecord | undefined;
+  removeAttachment(documentId: string, attachmentId: string, clinicId: string): boolean;
+};
+
+const docStore = new Map<string, DocumentRecord>();
+const attStore = new Map<string, AttachmentRecord[]>();
+
+function docKey(id: string, clinicId: string): string {
+  return `${clinicId}::${id}`;
+}
+
+function patientKey(patientId: string, clinicId: string): string {
+  return `${clinicId}::${patientId}`;
+}
+
+function attKey(documentId: string, clinicId: string): string {
+  return `${clinicId}::${documentId}`;
+}
+
+const patientIndex = new Map<string, string[]>();
+
+export function createDocumentsService(): DocumentsService {
+  return {
+    findByPatientId(patientId: string, clinicId: string) {
+      const keys = patientIndex.get(patientKey(patientId, clinicId)) || [];
+      return keys.map((k) => docStore.get(k)).filter(Boolean) as DocumentRecord[];
+    },
+
+    findById(documentId: string, clinicId: string) {
+      return docStore.get(docKey(documentId, clinicId));
+    },
+
+    create(patientId: string, clinicId: string, data: CreateDocumentBody) {
+      const now = new Date().toISOString();
+      const id = `doc_${Date.now()}`;
+      const record: DocumentRecord = {
+        id,
+        patientId,
+        clinicId,
+        status: "pending",
+        ...data,
+        tags: data.tags || [],
+        createdAt: now,
+        updatedAt: now,
+      };
+      docStore.set(docKey(id, clinicId), record);
+      const pk = patientKey(patientId, clinicId);
+      const existing = patientIndex.get(pk) || [];
+      existing.push(docKey(id, clinicId));
+      patientIndex.set(pk, existing);
+      return record;
+    },
+
+    update(documentId: string, clinicId: string, data: UpdateDocumentBody) {
+      const existing = docStore.get(docKey(documentId, clinicId));
+      if (!existing) return undefined;
+      const updated: DocumentRecord = {
+        ...existing,
+        ...data,
+        tags: data.tags || existing.tags,
+        updatedAt: new Date().toISOString(),
+      };
+      docStore.set(docKey(documentId, clinicId), updated);
+      return updated;
+    },
+
+    delete(documentId: string, clinicId: string) {
+      const record = docStore.get(docKey(documentId, clinicId));
+      if (!record) return false;
+      docStore.delete(docKey(documentId, clinicId));
+      const pk = patientKey(record.patientId, clinicId);
+      const keys = (patientIndex.get(pk) || []).filter((k) => k !== docKey(documentId, clinicId));
+      if (keys.length) patientIndex.set(pk, keys);
+      else patientIndex.delete(pk);
+      attStore.delete(attKey(documentId, clinicId));
+      return true;
+    },
+
+    getAttachments(documentId: string, clinicId: string) {
+      return attStore.get(attKey(documentId, clinicId)) || [];
+    },
+
+    addAttachment(documentId: string, clinicId: string, data: UploadAttachmentBody) {
+      if (!docStore.has(docKey(documentId, clinicId))) return undefined;
+      const now = new Date().toISOString();
+      const attachment: AttachmentRecord = {
+        id: `att_${Date.now()}`,
+        ...data,
+        createdAt: now,
+      };
+      const existing = attStore.get(attKey(documentId, clinicId)) || [];
+      existing.push(attachment);
+      attStore.set(attKey(documentId, clinicId), existing);
+      return attachment;
+    },
+
+    removeAttachment(documentId: string, attachmentId: string, clinicId: string) {
+      const existing = attStore.get(attKey(documentId, clinicId));
+      if (!existing) return false;
+      const filtered = existing.filter((a) => a.id !== attachmentId);
+      if (filtered.length === existing.length) return false;
+      if (filtered.length) attStore.set(attKey(documentId, clinicId), filtered);
+      else attStore.delete(attKey(documentId, clinicId));
+      return true;
+    },
+  };
+}
+
+const service = createDocumentsService();
+
+export function documentsRouter(req: Request, res: Response, next: NextFunction) {
+  const { patientId, documentId, attachmentId } = req.params;
+  const clinicId = (req.headers["x-clinic-id"] as string) || "default";
+  const method = req.method.toUpperCase();
+
+  if (method === "GET" && patientId && !documentId) {
+    const records = service.findByPatientId(patientId, clinicId);
+    res.json(records);
+    return;
+  }
+
+  if (method === "GET" && documentId && !attachmentId) {
+    const record = service.findById(documentId, clinicId);
+    if (!record) { res.status(404).json({ error: "NOT_FOUND" }); return; }
+    res.json(record);
+    return;
+  }
+
+  if (method === "GET" && documentId && attachmentId === "attachments") {
+    const attachments = service.getAttachments(documentId, clinicId);
+    res.json(attachments);
+    return;
+  }
+
+  if (method === "POST" && patientId && !documentId) {
+    const record = service.create(patientId, clinicId, req.body as CreateDocumentBody);
+    res.status(201).json(record);
+    return;
+  }
+
+  if (method === "POST" && documentId && attachmentId === "attachments") {
+    const attachment = service.addAttachment(documentId, clinicId, req.body as UploadAttachmentBody);
+    if (!attachment) { res.status(404).json({ error: "DOCUMENT_NOT_FOUND" }); return; }
+    res.status(201).json(attachment);
+    return;
+  }
+
+  if (method === "PATCH" && documentId) {
+    const record = service.update(documentId, clinicId, req.body as UpdateDocumentBody);
+    if (!record) { res.status(404).json({ error: "NOT_FOUND" }); return; }
+    res.json(record);
+    return;
+  }
+
+  if (method === "DELETE" && documentId && !attachmentId) {
+    const ok = service.delete(documentId, clinicId);
+    if (!ok) { res.status(404).json({ error: "NOT_FOUND" }); return; }
+    res.json({ ok: true });
+    return;
+  }
+
+  if (method === "DELETE" && documentId && attachmentId) {
+    const ok = service.removeAttachment(documentId, attachmentId, clinicId);
+    if (!ok) { res.status(404).json({ error: "NOT_FOUND" }); return; }
+    res.json({ ok: true });
+    return;
+  }
+
+  next();
+}

--- a/apps/api/src/documents/ui-flow.ts
+++ b/apps/api/src/documents/ui-flow.ts
@@ -1,0 +1,79 @@
+export type DocumentsFlowState = {
+  step: "idle" | "selecting" | "uploading" | "reviewing" | "submitting" | "success" | "error";
+  patientId: string;
+  editingDocumentId?: string;
+  error?: string;
+};
+
+export type UploadStep = "select-file" | "metadata" | "review";
+
+export type DocumentFormData = {
+  fileName: string;
+  fileType: string;
+  fileSizeBytes: number;
+  category: string;
+  description: string;
+  tags: string;
+  storageUrl: string;
+};
+
+export type AttachmentFormData = {
+  fileName: string;
+  mimeType: string;
+  fileSizeBytes: number;
+};
+
+export function getInitialFlowState(patientId: string): DocumentsFlowState {
+  return { step: "idle", patientId };
+}
+
+export function getNextUploadStep(current: UploadStep): UploadStep | null {
+  const steps: UploadStep[] = ["select-file", "metadata", "review"];
+  const idx = steps.indexOf(current);
+  return idx < steps.length - 1 ? steps[idx + 1] : null;
+}
+
+export function getPrevUploadStep(current: UploadStep): UploadStep | null {
+  const steps: UploadStep[] = ["select-file", "metadata", "review"];
+  const idx = steps.indexOf(current);
+  return idx > 0 ? steps[idx - 1] : null;
+}
+
+export function validateUploadStep(step: UploadStep, data: Partial<DocumentFormData>): string[] {
+  const errors: string[] = [];
+  if (step === "select-file") {
+    if (!data.fileName?.trim()) errors.push("File name is required");
+    if (!data.fileType?.trim()) errors.push("File type is required");
+    if (!data.fileSizeBytes || data.fileSizeBytes <= 0) errors.push("File size must be greater than 0");
+  }
+  if (step === "metadata") {
+    if (!data.category?.trim()) errors.push("Category is required");
+  }
+  return errors;
+}
+
+export function flowReducer(state: DocumentsFlowState, action: { type: string; payload?: unknown }): DocumentsFlowState {
+  switch (action.type) {
+    case "START_UPLOAD":
+      return { ...state, step: "uploading" };
+    case "START_REVIEW":
+      return { ...state, step: "reviewing" };
+    case "SUBMIT":
+      return { ...state, step: "submitting" };
+    case "SUCCESS":
+      return { ...state, step: "success", editingDocumentId: undefined };
+    case "ERROR":
+      return { ...state, step: "error", error: action.payload as string };
+    case "RESET":
+      return getInitialFlowState(state.patientId);
+    default:
+      return state;
+  }
+}
+
+export const fixtures = {
+  validFile: { fileName: "report.pdf", fileType: "application/pdf", fileSizeBytes: 102400, category: "lab-report", description: "Lab report", tags: "lab", storageUrl: "" } satisfies Partial<DocumentFormData>,
+  missingFile: {} satisfies Partial<DocumentFormData>,
+  validCategory: "lab-report",
+  invalidCategory: "unknown-category",
+};


### PR DESCRIPTION
Implements the documents and attachments module for the patient records foundation.

### Changes
- Add data model types, validation, and fixtures for DocumentRecord and AttachmentRecord
- Add service layer with in-memory store, CRUD operations, and Express router
- Add API contract definitions with endpoint metadata and URL builders
- Add UI flow state machine for document upload workflows

Closes #710
Closes #715
Closes #720
Closes #725