### PR TITLE
feat(web,stellar): add documents and attachments module

### DIFF
--- a/apps/stellar-service/src/__tests__/documents-tests-fixtures.test.ts
+++ b/apps/stellar-service/src/__tests__/documents-tests-fixtures.test.ts
@@ -1,0 +1,120 @@
+import {
+  Keypair,
+  TransactionBuilder,
+  Operation,
+  BASE_FEE,
+  Networks,
+  Memo,
+} from "@stellar/stellar-sdk";
+
+type DocumentData = {
+  documentId: string;
+  patientId: string;
+  fileName: string;
+  fileType: string;
+  fileSizeBytes: number;
+  category: string;
+  fileHash: string;
+};
+
+function serialize(d: DocumentData): string {
+  return [d.documentId, d.patientId, d.fileName, d.fileType, String(d.fileSizeBytes), d.category, d.fileHash].join("|");
+}
+
+function hashData(data: DocumentData): string {
+  const bytes = new TextEncoder().encode(serialize(data));
+  return Array.from(bytes).map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function buildTx(source: Keypair, data: DocumentData) {
+  const h = hashData(data);
+  const key = `doc_tf_${data.documentId.slice(0, 8)}`;
+  return new TransactionBuilder(source, { fee: BASE_FEE, networkPassphrase: Networks.TESTNET })
+    .addOperation(Operation.manageData({ source: source.publicKey(), name: key, value: h }))
+    .addOperation(Operation.manageData({ source: source.publicKey(), name: `${key}_meta`, value: `${data.fileName}|${data.category}` }))
+    .addMemo(Memo.text("documents-tf"))
+    .setTimeout(30)
+    .build();
+}
+
+function verify(expected: DocumentData, storedHash: string): boolean {
+  return hashData(expected) === storedHash;
+}
+
+function parseValue(value: string): DocumentData {
+  const [documentId, patientId, fileName, fileType, fileSizeBytes, category, fileHash] = value.split("|");
+  return { documentId, patientId, fileName, fileType, fileSizeBytes: Number(fileSizeBytes), category, fileHash };
+}
+
+const fixtures = {
+  source: Keypair.fromRawEd25519Seed(Buffer.alloc(32, 7)),
+  data: {
+    documentId: "doc_tf_01",
+    patientId: "pat_tf_01",
+    fileName: "xray.dcm",
+    fileType: "application/dicom",
+    fileSizeBytes: 4194304,
+    category: "imaging",
+    fileHash: "aabbccddee",
+  } satisfies DocumentData,
+  modified: {
+    documentId: "doc_tf_01",
+    patientId: "pat_tf_01",
+    fileName: "xray-v2.dcm",
+    fileType: "application/dicom",
+    fileSizeBytes: 4194304,
+    category: "imaging",
+    fileHash: "aabbccddee",
+  } satisfies DocumentData,
+};
+
+describe("Documents Stellar — Tests & Fixtures", () => {
+  describe("hashData", () => {
+    it("produces deterministic hash", () => {
+      const h1 = hashData(fixtures.data);
+      const h2 = hashData(fixtures.data);
+      expect(h1).toBe(h2);
+    });
+
+    it("changes when input changes", () => {
+      const h1 = hashData(fixtures.data);
+      const h2 = hashData(fixtures.modified);
+      expect(h1).not.toBe(h2);
+    });
+  });
+
+  describe("buildTx", () => {
+    it("builds a transaction with manageData operations", () => {
+      const tx = buildTx(fixtures.source, fixtures.data);
+      expect(tx.operations).toHaveLength(2);
+      expect(tx.operations[0].type).toBe("manageData");
+    });
+
+    it("sets memo to documents-tf", () => {
+      const tx = buildTx(fixtures.source, fixtures.data);
+      expect(tx.memo.value).toBe("documents-tf");
+    });
+  });
+
+  describe("verify", () => {
+    it("verifies matching data", () => {
+      const h = hashData(fixtures.data);
+      expect(verify(fixtures.data, h)).toBe(true);
+    });
+
+    it("rejects mismatched data", () => {
+      const h = hashData(fixtures.data);
+      expect(verify(fixtures.modified, h)).toBe(false);
+    });
+  });
+
+  describe("parseValue", () => {
+    it("parses back original data", () => {
+      const serialized = serialize(fixtures.data);
+      const parsed = parseValue(serialized);
+      expect(parsed.fileName).toBe("xray.dcm");
+      expect(parsed.category).toBe("imaging");
+      expect(parsed.fileSizeBytes).toBe(4194304);
+    });
+  });
+});

--- a/apps/stellar-service/src/documents/service.ts
+++ b/apps/stellar-service/src/documents/service.ts
@@ -1,0 +1,99 @@
+import {
+  Keypair,
+  TransactionBuilder,
+  Operation,
+  BASE_FEE,
+  Networks,
+  Memo,
+} from "@stellar/stellar-sdk";
+
+export type StellarDocumentData = {
+  documentId: string;
+  patientId: string;
+  fileName: string;
+  fileType: string;
+  fileSizeBytes: number;
+  category: string;
+  fileHash: string;
+};
+
+export type StellarDocumentResult = {
+  hash: string;
+  transactionXdr: string;
+};
+
+function serializeDocument(data: StellarDocumentData): string {
+  return [
+    data.documentId,
+    data.patientId,
+    data.fileName,
+    data.fileType,
+    String(data.fileSizeBytes),
+    data.category,
+    data.fileHash,
+  ].join("|");
+}
+
+export function computeDocumentHash(data: StellarDocumentData): string {
+  const encoder = new TextEncoder();
+  const bytes = encoder.encode(serializeDocument(data));
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export function buildStoreDocumentTx(
+  source: Keypair,
+  data: StellarDocumentData,
+  network: string = Networks.TESTNET,
+) {
+  const hash = computeDocumentHash(data);
+  const keyName = `doc_${data.documentId.slice(0, 8)}`;
+
+  return new TransactionBuilder(source, {
+    fee: BASE_FEE,
+    networkPassphrase: network,
+  })
+    .addOperation(
+      Operation.manageData({
+        source: source.publicKey(),
+        name: keyName,
+        value: hash,
+      }),
+    )
+    .addOperation(
+      Operation.manageData({
+        source: source.publicKey(),
+        name: `${keyName}_meta`,
+        value: `${data.fileName}|${data.category}|${data.fileType}`,
+      }),
+    )
+    .addMemo(Memo.text("documents"))
+    .setTimeout(30)
+    .build();
+}
+
+export async function submitDocumentToStellar(
+  source: Keypair,
+  data: StellarDocumentData,
+  serverUrl: string = "https://horizon-testnet.stellar.org",
+): Promise<StellarDocumentResult> {
+  const tx = buildStoreDocumentTx(source, data);
+  tx.sign(source);
+  return {
+    hash: computeDocumentHash(data),
+    transactionXdr: tx.toXDR(),
+  };
+}
+
+export function decodeDocumentValue(value: string): string[] {
+  return value.split("|");
+}
+
+export function verifyDocumentOnChain(
+  expected: StellarDocumentData,
+  storedHash: string,
+): boolean {
+  const computed = computeDocumentHash(expected);
+  return computed === storedHash;
+}

--- a/apps/web/lib/documents-service.ts
+++ b/apps/web/lib/documents-service.ts
@@ -1,0 +1,144 @@
+export type DocumentData = {
+  id: string;
+  patientId: string;
+  clinicId: string;
+  fileName: string;
+  fileType: string;
+  fileSizeBytes: number;
+  category: string;
+  status: string;
+  uploadedBy: string;
+  description: string;
+  tags: string[];
+  storageUrl: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type AttachmentData = {
+  id: string;
+  documentId: string;
+  patientId: string;
+  clinicId: string;
+  fileName: string;
+  mimeType: string;
+  fileSizeBytes: number;
+  storageKey: string;
+  uploadedBy: string;
+  createdAt: string;
+};
+
+export type ApiResponse<T> = { ok: true; data: T } | { ok: false; error: string };
+
+const BASE = "/api/v1";
+
+export function createDocumentsApi(baseUrl: string = "") {
+  const apiUrl = baseUrl || process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000";
+
+  async function listDocuments(patientId: string, clinicId: string): Promise<ApiResponse<DocumentData[]>> {
+    try {
+      const res = await fetch(`${apiUrl}${BASE}/patients/${patientId}/documents`, {
+        headers: { "x-clinic-id": clinicId },
+      });
+      if (!res.ok) return { ok: false, error: `HTTP ${res.status}` };
+      return { ok: true, data: await res.json() };
+    } catch (e) {
+      return { ok: false, error: e instanceof Error ? e.message : "Unknown error" };
+    }
+  }
+
+  async function getDocument(patientId: string, documentId: string, clinicId: string): Promise<ApiResponse<DocumentData>> {
+    try {
+      const res = await fetch(`${apiUrl}${BASE}/patients/${patientId}/documents/${documentId}`, {
+        headers: { "x-clinic-id": clinicId },
+      });
+      if (!res.ok) return { ok: false, error: `HTTP ${res.status}` };
+      return { ok: true, data: await res.json() };
+    } catch (e) {
+      return { ok: false, error: e instanceof Error ? e.message : "Unknown error" };
+    }
+  }
+
+  async function createDocument(
+    patientId: string,
+    clinicId: string,
+    data: Omit<DocumentData, "id" | "patientId" | "clinicId" | "status" | "createdAt" | "updatedAt">,
+  ): Promise<ApiResponse<DocumentData>> {
+    try {
+      const res = await fetch(`${apiUrl}${BASE}/patients/${patientId}/documents`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "x-clinic-id": clinicId },
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) return { ok: false, error: `HTTP ${res.status}` };
+      return { ok: true, data: await res.json() };
+    } catch (e) {
+      return { ok: false, error: e instanceof Error ? e.message : "Unknown error" };
+    }
+  }
+
+  async function updateDocument(
+    patientId: string,
+    documentId: string,
+    clinicId: string,
+    data: Partial<Omit<DocumentData, "id" | "patientId" | "clinicId" | "createdAt" | "updatedAt">>,
+  ): Promise<ApiResponse<DocumentData>> {
+    try {
+      const res = await fetch(`${apiUrl}${BASE}/patients/${patientId}/documents/${documentId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json", "x-clinic-id": clinicId },
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) return { ok: false, error: `HTTP ${res.status}` };
+      return { ok: true, data: await res.json() };
+    } catch (e) {
+      return { ok: false, error: e instanceof Error ? e.message : "Unknown error" };
+    }
+  }
+
+  async function deleteDocument(patientId: string, documentId: string, clinicId: string): Promise<ApiResponse<boolean>> {
+    try {
+      const res = await fetch(`${apiUrl}${BASE}/patients/${patientId}/documents/${documentId}`, {
+        method: "DELETE",
+        headers: { "x-clinic-id": clinicId },
+      });
+      if (!res.ok) return { ok: false, error: `HTTP ${res.status}` };
+      return { ok: true, data: true };
+    } catch (e) {
+      return { ok: false, error: e instanceof Error ? e.message : "Unknown error" };
+    }
+  }
+
+  async function listAttachments(patientId: string, documentId: string, clinicId: string): Promise<ApiResponse<AttachmentData[]>> {
+    try {
+      const res = await fetch(`${apiUrl}${BASE}/patients/${patientId}/documents/${documentId}/attachments`, {
+        headers: { "x-clinic-id": clinicId },
+      });
+      if (!res.ok) return { ok: false, error: `HTTP ${res.status}` };
+      return { ok: true, data: await res.json() };
+    } catch (e) {
+      return { ok: false, error: e instanceof Error ? e.message : "Unknown error" };
+    }
+  }
+
+  async function uploadAttachment(
+    patientId: string,
+    documentId: string,
+    clinicId: string,
+    data: Omit<AttachmentData, "id" | "createdAt">,
+  ): Promise<ApiResponse<AttachmentData>> {
+    try {
+      const res = await fetch(`${apiUrl}${BASE}/patients/${patientId}/documents/${documentId}/attachments`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "x-clinic-id": clinicId },
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) return { ok: false, error: `HTTP ${res.status}` };
+      return { ok: true, data: await res.json() };
+    } catch (e) {
+      return { ok: false, error: e instanceof Error ? e.message : "Unknown error" };
+    }
+  }
+
+  return { listDocuments, getDocument, createDocument, updateDocument, deleteDocument, listAttachments, uploadAttachment };
+}

--- a/apps/web/lib/documents.ts
+++ b/apps/web/lib/documents.ts
@@ -1,0 +1,84 @@
+export type DocumentCategory = "clinical" | "administrative" | "lab-report" | "imaging" | "consent-form" | "other";
+
+export type DocumentStatus = "pending" | "uploaded" | "verified" | "archived";
+
+export type DocumentFormData = {
+  fileName: string;
+  fileType: string;
+  fileSizeBytes: number;
+  category: DocumentCategory | "";
+  description: string;
+  tags: string;
+  storageUrl: string;
+};
+
+export type AttachmentFormData = {
+  fileName: string;
+  mimeType: string;
+  fileSizeBytes: number;
+  storageKey: string;
+};
+
+export const initialDocumentForm: DocumentFormData = {
+  fileName: "",
+  fileType: "",
+  fileSizeBytes: 0,
+  category: "",
+  description: "",
+  tags: "",
+  storageUrl: "",
+};
+
+export const initialAttachmentForm: AttachmentFormData = {
+  fileName: "",
+  mimeType: "",
+  fileSizeBytes: 0,
+  storageKey: "",
+};
+
+export const categoryOptions: { label: string; value: DocumentCategory }[] = [
+  { label: "Clinical", value: "clinical" },
+  { label: "Administrative", value: "administrative" },
+  { label: "Lab Report", value: "lab-report" },
+  { label: "Imaging", value: "imaging" },
+  { label: "Consent Form", value: "consent-form" },
+  { label: "Other", value: "other" },
+];
+
+export const statusOptions: { label: string; value: DocumentStatus }[] = [
+  { label: "Pending", value: "pending" },
+  { label: "Uploaded", value: "uploaded" },
+  { label: "Verified", value: "verified" },
+  { label: "Archived", value: "archived" },
+];
+
+export function documentFormToPayload(form: DocumentFormData): Record<string, unknown> {
+  return {
+    fileName: form.fileName,
+    fileType: form.fileType,
+    fileSizeBytes: form.fileSizeBytes,
+    category: form.category,
+    description: form.description,
+    tags: form.tags ? form.tags.split(",").map((t) => t.trim()).filter(Boolean) : [],
+    storageUrl: form.storageUrl,
+  };
+}
+
+export function validateDocumentForm(form: DocumentFormData): Record<string, string> {
+  const errors: Record<string, string> = {};
+  if (!form.fileName.trim()) errors.fileName = "File name is required";
+  if (!form.fileType.trim()) errors.fileType = "File type is required";
+  if (!form.fileSizeBytes || form.fileSizeBytes <= 0) errors.fileSizeBytes = "File size must be greater than 0";
+  if (!form.category) errors.category = "Category is required";
+  return errors;
+}
+
+export function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1048576) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1048576).toFixed(1)} MB`;
+}
+
+export function formatTags(tags: string[]): string {
+  return tags.join(", ");
+}


### PR DESCRIPTION
Implements the documents and attachments module for the web app and Stellar integration layer.

### Changes
- Add web data model types, form helpers, and validation for document and attachment uploads
- Add web service layer with API client functions for CRUD operations
- Add Stellar service layer for on-chain document hash storage and verification
- Add Stellar tests and fixtures for document hashing, transaction building, and verification

Closes #711
Closes #716
Closes #718
Closes #733