### PR TITLE
feat(mobile): add documents and attachments module

### DIFF
--- a/apps/mobile/src/contracts/documents.ts
+++ b/apps/mobile/src/contracts/documents.ts
@@ -1,0 +1,199 @@
+export type DocumentDTO = {
+  id: string;
+  patientId: string;
+  clinicId: string;
+  fileName: string;
+  fileType: string;
+  fileSizeBytes: number;
+  category: string;
+  status: string;
+  uploadedBy: string;
+  description: string;
+  tags: string[];
+  storageUrl: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type AttachmentDTO = {
+  id: string;
+  documentId: string;
+  patientId: string;
+  clinicId: string;
+  fileName: string;
+  mimeType: string;
+  fileSizeBytes: number;
+  storageKey: string;
+  uploadedBy: string;
+  createdAt: string;
+};
+
+export type ContractResponse<T> =
+  | { status: "success"; data: T; code: number }
+  | { status: "error"; message: string; code: number };
+
+function buildListPath(patientId: string): string {
+  return `/api/v1/patients/${encodeURIComponent(patientId)}/documents`;
+}
+
+function buildItemPath(patientId: string, documentId: string): string {
+  return `/api/v1/patients/${encodeURIComponent(patientId)}/documents/${encodeURIComponent(documentId)}`;
+}
+
+function buildAttachmentPath(patientId: string, documentId: string): string {
+  return `${buildItemPath(patientId, documentId)}/attachments`;
+}
+
+export async function listDocumentsContract(
+  baseUrl: string,
+  patientId: string,
+  clinicId: string,
+): Promise<ContractResponse<DocumentDTO[]>> {
+  try {
+    const res = await fetch(`${baseUrl}${buildListPath(patientId)}`, {
+      headers: { "x-clinic-id": clinicId },
+    });
+    const data = await res.json();
+    if (!res.ok) return { status: "error", message: data.error || "Unknown error", code: res.status };
+    return { status: "success", data: data as DocumentDTO[], code: res.status };
+  } catch (e) {
+    return { status: "error", message: e instanceof Error ? e.message : "Network error", code: 0 };
+  }
+}
+
+export async function getDocumentContract(
+  baseUrl: string,
+  patientId: string,
+  documentId: string,
+  clinicId: string,
+): Promise<ContractResponse<DocumentDTO>> {
+  try {
+    const res = await fetch(`${baseUrl}${buildItemPath(patientId, documentId)}`, {
+      headers: { "x-clinic-id": clinicId },
+    });
+    const data = await res.json();
+    if (!res.ok) return { status: "error", message: data.error || "Unknown error", code: res.status };
+    return { status: "success", data: data as DocumentDTO, code: res.status };
+  } catch (e) {
+    return { status: "error", message: e instanceof Error ? e.message : "Network error", code: 0 };
+  }
+}
+
+export async function createDocumentContract(
+  baseUrl: string,
+  patientId: string,
+  clinicId: string,
+  body: Omit<DocumentDTO, "id" | "patientId" | "clinicId" | "status" | "createdAt" | "updatedAt">,
+): Promise<ContractResponse<DocumentDTO>> {
+  try {
+    const res = await fetch(`${baseUrl}${buildListPath(patientId)}`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-clinic-id": clinicId },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json();
+    if (!res.ok) return { status: "error", message: data.error || "Validation failed", code: res.status };
+    return { status: "success", data: data as DocumentDTO, code: res.status };
+  } catch (e) {
+    return { status: "error", message: e instanceof Error ? e.message : "Network error", code: 0 };
+  }
+}
+
+export async function updateDocumentContract(
+  baseUrl: string,
+  patientId: string,
+  documentId: string,
+  clinicId: string,
+  body: Partial<Omit<DocumentDTO, "id" | "patientId" | "clinicId" | "createdAt" | "updatedAt">>,
+): Promise<ContractResponse<DocumentDTO>> {
+  try {
+    const res = await fetch(`${baseUrl}${buildItemPath(patientId, documentId)}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json", "x-clinic-id": clinicId },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json();
+    if (!res.ok) return { status: "error", message: data.error || "Update failed", code: res.status };
+    return { status: "success", data: data as DocumentDTO, code: res.status };
+  } catch (e) {
+    return { status: "error", message: e instanceof Error ? e.message : "Network error", code: 0 };
+  }
+}
+
+export async function deleteDocumentContract(
+  baseUrl: string,
+  patientId: string,
+  documentId: string,
+  clinicId: string,
+): Promise<ContractResponse<{ ok: boolean }>> {
+  try {
+    const res = await fetch(`${baseUrl}${buildItemPath(patientId, documentId)}`, {
+      method: "DELETE",
+      headers: { "x-clinic-id": clinicId },
+    });
+    const data = await res.json();
+    if (!res.ok) return { status: "error", message: data.error || "Delete failed", code: res.status };
+    return { status: "success", data: data as { ok: boolean }, code: res.status };
+  } catch (e) {
+    return { status: "error", message: e instanceof Error ? e.message : "Network error", code: 0 };
+  }
+}
+
+export async function listAttachmentsContract(
+  baseUrl: string,
+  patientId: string,
+  documentId: string,
+  clinicId: string,
+): Promise<ContractResponse<AttachmentDTO[]>> {
+  try {
+    const res = await fetch(`${baseUrl}${buildAttachmentPath(patientId, documentId)}`, {
+      headers: { "x-clinic-id": clinicId },
+    });
+    const data = await res.json();
+    if (!res.ok) return { status: "error", message: data.error || "Unknown error", code: res.status };
+    return { status: "success", data: data as AttachmentDTO[], code: res.status };
+  } catch (e) {
+    return { status: "error", message: e instanceof Error ? e.message : "Network error", code: 0 };
+  }
+}
+
+export async function uploadAttachmentContract(
+  baseUrl: string,
+  patientId: string,
+  documentId: string,
+  clinicId: string,
+  body: Omit<AttachmentDTO, "id" | "createdAt">,
+): Promise<ContractResponse<AttachmentDTO>> {
+  try {
+    const res = await fetch(`${baseUrl}${buildAttachmentPath(patientId, documentId)}`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-clinic-id": clinicId },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json();
+    if (!res.ok) return { status: "error", message: data.error || "Upload failed", code: res.status };
+    return { status: "success", data: data as AttachmentDTO, code: res.status };
+  } catch (e) {
+    return { status: "error", message: e instanceof Error ? e.message : "Network error", code: 0 };
+  }
+}
+
+export async function deleteAttachmentContract(
+  baseUrl: string,
+  patientId: string,
+  documentId: string,
+  attachmentId: string,
+  clinicId: string,
+): Promise<ContractResponse<{ ok: boolean }>> {
+  try {
+    const res = await fetch(`${baseUrl}${buildAttachmentPath(patientId, documentId)}/${encodeURIComponent(attachmentId)}`, {
+      method: "DELETE",
+      headers: { "x-clinic-id": clinicId },
+    });
+    const data = await res.json();
+    if (!res.ok) return { status: "error", message: data.error || "Delete failed", code: res.status };
+    return { status: "success", data: data as { ok: boolean }, code: res.status };
+  } catch (e) {
+    return { status: "error", message: e instanceof Error ? e.message : "Network error", code: 0 };
+  }
+}

--- a/apps/mobile/src/models/documents.ts
+++ b/apps/mobile/src/models/documents.ts
@@ -1,0 +1,86 @@
+export type DocumentCategory = "clinical" | "administrative" | "lab-report" | "imaging" | "consent-form" | "other";
+
+export type DocumentStatus = "pending" | "uploaded" | "verified" | "archived";
+
+export type Document = {
+  id: string;
+  patientId: string;
+  fileName: string;
+  fileType: string;
+  fileSizeBytes: number;
+  category: DocumentCategory;
+  status: DocumentStatus;
+  description: string;
+  tags: string[];
+  uploadedAt: string;
+};
+
+export type Attachment = {
+  id: string;
+  documentId: string;
+  fileName: string;
+  mimeType: string;
+  fileSizeBytes: number;
+  uploadedAt: string;
+};
+
+export type DocumentSummary = {
+  id: string;
+  fileName: string;
+  category: DocumentCategory;
+  status: DocumentStatus;
+  fileSizeLabel: string;
+};
+
+export function calculateFileSizeLabel(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1048576) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1048576).toFixed(1)} MB`;
+}
+
+export function documentToSummary(d: Document): DocumentSummary {
+  return {
+    id: d.id,
+    fileName: d.fileName,
+    category: d.category,
+    status: d.status,
+    fileSizeLabel: calculateFileSizeLabel(d.fileSizeBytes),
+  };
+}
+
+export function validateDocumentRecord(data: Partial<Document>): string[] {
+  const errors: string[] = [];
+  if (!data.fileName) errors.push("File name is required");
+  if (!data.category) errors.push("Category is required");
+  if (!data.fileSizeBytes || data.fileSizeBytes <= 0) errors.push("File size is required");
+  return errors;
+}
+
+export const defaultDocument: Document = {
+  id: "",
+  patientId: "",
+  fileName: "",
+  fileType: "",
+  fileSizeBytes: 0,
+  category: "other",
+  status: "pending",
+  description: "",
+  tags: [],
+  uploadedAt: "",
+};
+
+export const categoryOptions: { label: string; value: DocumentCategory }[] = [
+  { label: "Clinical", value: "clinical" },
+  { label: "Administrative", value: "administrative" },
+  { label: "Lab Report", value: "lab-report" },
+  { label: "Imaging", value: "imaging" },
+  { label: "Consent Form", value: "consent-form" },
+  { label: "Other", value: "other" },
+];
+
+export const statusOptions: { label: string; value: DocumentStatus }[] = [
+  { label: "Pending", value: "pending" },
+  { label: "Uploaded", value: "uploaded" },
+  { label: "Verified", value: "verified" },
+  { label: "Archived", value: "archived" },
+];

--- a/apps/mobile/src/services/documents.ts
+++ b/apps/mobile/src/services/documents.ts
@@ -1,0 +1,120 @@
+export type DocumentDTO = {
+  id: string;
+  patientId: string;
+  clinicId: string;
+  fileName: string;
+  fileType: string;
+  fileSizeBytes: number;
+  category: string;
+  status: string;
+  uploadedBy: string;
+  description: string;
+  tags: string[];
+  storageUrl: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type AttachmentDTO = {
+  id: string;
+  documentId: string;
+  patientId: string;
+  clinicId: string;
+  fileName: string;
+  mimeType: string;
+  fileSizeBytes: number;
+  storageKey: string;
+  uploadedBy: string;
+  createdAt: string;
+};
+
+export type ServiceResult<T> = { type: "success"; data: T } | { type: "error"; message: string };
+
+const API_BASE = "/api/v1";
+
+export function createMobileDocumentsService(baseUrl: string) {
+  async function request<T>(
+    path: string,
+    options: RequestInit = {},
+  ): Promise<ServiceResult<T>> {
+    try {
+      const res = await fetch(`${baseUrl}${path}`, {
+        ...options,
+        headers: {
+          "Content-Type": "application/json",
+          ...(options.headers as Record<string, string>),
+        },
+      });
+      if (!res.ok) return { type: "error", message: `HTTP ${res.status}: ${res.statusText}` };
+      return { type: "success", data: await res.json() };
+    } catch (e) {
+      return { type: "error", message: e instanceof Error ? e.message : "Network error" };
+    }
+  }
+
+  function listDocuments(patientId: string, clinicId: string) {
+    return request<DocumentDTO[]>(
+      `${API_BASE}/patients/${patientId}/documents`,
+      { headers: { "x-clinic-id": clinicId } },
+    );
+  }
+
+  function getDocument(patientId: string, documentId: string, clinicId: string) {
+    return request<DocumentDTO>(
+      `${API_BASE}/patients/${patientId}/documents/${documentId}`,
+      { headers: { "x-clinic-id": clinicId } },
+    );
+  }
+
+  function createDocument(patientId: string, clinicId: string, data: Omit<DocumentDTO, "id" | "patientId" | "clinicId" | "status" | "createdAt" | "updatedAt">) {
+    return request<DocumentDTO>(
+      `${API_BASE}/patients/${patientId}/documents`,
+      {
+        method: "POST",
+        headers: { "x-clinic-id": clinicId },
+        body: JSON.stringify(data),
+      },
+    );
+  }
+
+  function updateDocument(patientId: string, documentId: string, clinicId: string, data: Partial<Omit<DocumentDTO, "id" | "patientId" | "clinicId" | "createdAt" | "updatedAt">>) {
+    return request<DocumentDTO>(
+      `${API_BASE}/patients/${patientId}/documents/${documentId}`,
+      {
+        method: "PATCH",
+        headers: { "x-clinic-id": clinicId },
+        body: JSON.stringify(data),
+      },
+    );
+  }
+
+  function deleteDocument(patientId: string, documentId: string, clinicId: string) {
+    return request<{ ok: boolean }>(
+      `${API_BASE}/patients/${patientId}/documents/${documentId}`,
+      {
+        method: "DELETE",
+        headers: { "x-clinic-id": clinicId },
+      },
+    );
+  }
+
+  function listAttachments(patientId: string, documentId: string, clinicId: string) {
+    return request<AttachmentDTO[]>(
+      `${API_BASE}/patients/${patientId}/documents/${documentId}/attachments`,
+      { headers: { "x-clinic-id": clinicId } },
+    );
+  }
+
+  function uploadAttachment(patientId: string, documentId: string, clinicId: string, data: Omit<AttachmentDTO, "id" | "createdAt">) {
+    return request<AttachmentDTO>(
+      `${API_BASE}/patients/${patientId}/documents/${documentId}/attachments`,
+      {
+        method: "POST",
+        headers: { "x-clinic-id": clinicId },
+        body: JSON.stringify(data),
+      },
+    );
+  }
+
+  return { listDocuments, getDocument, createDocument, updateDocument, deleteDocument, listAttachments, uploadAttachment };
+}

--- a/apps/mobile/src/ui/documents.ts
+++ b/apps/mobile/src/ui/documents.ts
@@ -1,0 +1,71 @@
+export type DocumentUploadStep = "file" | "category" | "confirm" | "done";
+
+export type DocumentEntry = {
+  patientId: string;
+  fileName: string;
+  fileType: string;
+  fileSizeBytes: number;
+  category: string;
+  description: string;
+  tags: string[];
+};
+
+export type StepState = {
+  step: DocumentUploadStep;
+  entry: DocumentEntry;
+  errors: string[];
+};
+
+const emptyEntry: DocumentEntry = {
+  patientId: "",
+  fileName: "",
+  fileType: "",
+  fileSizeBytes: 0,
+  category: "",
+  description: "",
+  tags: [],
+};
+
+export function createInitialState(): StepState {
+  return { step: "file", entry: { ...emptyEntry }, errors: [] };
+}
+
+export function nextStep(current: DocumentUploadStep): DocumentUploadStep | null {
+  const steps: DocumentUploadStep[] = ["file", "category", "confirm", "done"];
+  const idx = steps.indexOf(current);
+  return idx < steps.length - 1 ? steps[idx + 1] : null;
+}
+
+export function prevStep(current: DocumentUploadStep): DocumentUploadStep | null {
+  const steps: DocumentUploadStep[] = ["file", "category", "confirm", "done"];
+  const idx = steps.indexOf(current);
+  return idx > 0 ? steps[idx - 1] : null;
+}
+
+export function validateStep(step: DocumentUploadStep, entry: DocumentEntry): string[] {
+  const errors: string[] = [];
+  if (step === "file") {
+    if (!entry.fileName.trim()) errors.push("File name is required");
+    if (!entry.fileType.trim()) errors.push("File type is required");
+    if (entry.fileSizeBytes <= 0) errors.push("File size is required");
+  }
+  if (step === "category") {
+    if (!entry.category.trim()) errors.push("Category is required");
+  }
+  return errors;
+}
+
+export function getSummary(entry: DocumentEntry): string {
+  const sizeLabel = entry.fileSizeBytes >= 1048576
+    ? `${(entry.fileSizeBytes / 1048576).toFixed(1)} MB`
+    : entry.fileSizeBytes >= 1024
+      ? `${(entry.fileSizeBytes / 1024).toFixed(1)} KB`
+      : `${entry.fileSizeBytes} B`;
+  return `${entry.fileName} (${sizeLabel}) — ${entry.category}`;
+}
+
+export const fixtures = {
+  validFile: { fileName: "scan.dcm", fileType: "application/dicom", fileSizeBytes: 2097152 } as Partial<DocumentEntry>,
+  validCategory: { category: "imaging" } as Partial<DocumentEntry>,
+  invalidFile: { fileSizeBytes: 0 } as Partial<DocumentEntry>,
+};


### PR DESCRIPTION
Implements the documents and attachments module for the mobile workspace.

### Changes
- Add mobile data model types, summary helpers, and validation for documents and attachments
- Add mobile service layer with API client functions for document CRUD and attachment upload
- Add mobile contract layer with individual fetch-based functions for each API operation
- Add mobile UI flow state machine for document upload workflows

Closes #712
Closes #717
Closes #722
Closes #727