### PR TITLE
feat(web,api,tests): add documents and attachments contract, UI flow, and tests

### DIFF
--- a/apps/api/src/__tests__/documents-tests-fixtures.test.ts
+++ b/apps/api/src/__tests__/documents-tests-fixtures.test.ts
@@ -1,0 +1,174 @@
+import type { Request, Response } from "express";
+
+type DocumentRecord = {
+  id: string;
+  patientId: string;
+  clinicId: string;
+  fileName: string;
+  fileType: string;
+  fileSizeBytes: number;
+  category: string;
+  status: string;
+  uploadedBy: string;
+  description: string;
+  tags: string[];
+  storageUrl: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type CreateDocumentInput = Omit<DocumentRecord, "id" | "clinicId" | "status" | "createdAt" | "updatedAt">;
+
+const db = new Map<string, DocumentRecord[]>();
+const k = (pid: string) => pid;
+
+function getDocuments(patientId: string): DocumentRecord[] {
+  return db.get(k(patientId)) || [];
+}
+
+const validCategories = ["clinical", "administrative", "lab-report", "imaging", "consent-form", "other"];
+
+export function handleCreateDocument(req: Request, res: Response) {
+  const body = req.body as CreateDocumentInput;
+  if (!body.fileName || !body.fileType || !body.category) {
+    res.status(400).json({ error: "VALIDATION_ERROR", message: "fileName, fileType, and category are required" });
+    return;
+  }
+  if (!validCategories.includes(body.category)) {
+    res.status(400).json({ error: "VALIDATION_ERROR", message: "category is not valid" });
+    return;
+  }
+  const now = new Date().toISOString();
+  const doc: DocumentRecord = {
+    id: `doc_${Date.now()}`,
+    patientId: req.params.patientId,
+    clinicId: (req.headers["x-clinic-id"] as string) || "default",
+    status: "pending",
+    ...body,
+    tags: body.tags || [],
+    createdAt: now,
+    updatedAt: now,
+  };
+  const docs = getDocuments(req.params.patientId);
+  docs.push(doc);
+  db.set(k(req.params.patientId), docs);
+  res.status(201).json(doc);
+}
+
+export function handleListDocuments(req: Request, res: Response) {
+  const docs = getDocuments(req.params.patientId);
+  if (docs.length === 0) { res.status(404).json({ error: "NOT_FOUND" }); return; }
+  res.json(docs);
+}
+
+export function handleGetDocument(req: Request, res: Response) {
+  const docs = getDocuments(req.params.patientId);
+  const doc = docs.find((d) => d.id === req.params.documentId);
+  if (!doc) { res.status(404).json({ error: "NOT_FOUND" }); return; }
+  res.json(doc);
+}
+
+export function handleDeleteDocument(req: Request, res: Response) {
+  const docs = getDocuments(req.params.patientId);
+  const idx = docs.findIndex((d) => d.id === req.params.documentId);
+  if (idx === -1) { res.status(404).json({ error: "NOT_FOUND" }); return; }
+  docs.splice(idx, 1);
+  db.set(k(req.params.patientId), docs);
+  res.json({ ok: true });
+}
+
+export function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1048576) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1048576).toFixed(1)} MB`;
+}
+
+export function validateCategory(category: string): boolean {
+  return validCategories.includes(category);
+}
+
+const validDocument = {
+  patientId: "pat_tf_01",
+  fileName: "lab-result.pdf",
+  fileType: "application/pdf",
+  fileSizeBytes: 245760,
+  category: "lab-report",
+  uploadedBy: "staff_01",
+  description: "Complete blood count",
+  tags: ["lab", "blood"],
+  storageUrl: "https://storage.example.com/lab-result.pdf",
+};
+
+describe("Documents API — Tests & Fixtures", () => {
+  let res: Partial<Response>;
+  let json: jest.Mock;
+  let status: jest.Mock;
+
+  beforeEach(() => {
+    json = jest.fn();
+    status = jest.fn().mockReturnValue({ json });
+    res = { status, json };
+    db.clear();
+  });
+
+  it("creates a document record", () => {
+    handleCreateDocument({ params: { patientId: "pat_tf_01" }, headers: { "x-clinic-id": "clinic_01" }, body: validDocument } as unknown as Request, res as Response);
+    expect(status).toHaveBeenCalledWith(201);
+    expect(json).toHaveBeenCalledWith(expect.objectContaining({ patientId: "pat_tf_01", status: "pending" }));
+  });
+
+  it("rejects document without required fields", () => {
+    handleCreateDocument({ params: { patientId: "pat_tf_01" }, headers: {}, body: {} } as unknown as Request, res as Response);
+    expect(status).toHaveBeenCalledWith(400);
+  });
+
+  it("rejects document with invalid category", () => {
+    handleCreateDocument({ params: { patientId: "pat_tf_01" }, headers: {}, body: { ...validDocument, category: "invalid" } } as unknown as Request, res as Response);
+    expect(status).toHaveBeenCalledWith(400);
+  });
+
+  it("lists documents for a patient", () => {
+    handleCreateDocument({ params: { patientId: "pat_tf_01" }, headers: { "x-clinic-id": "clinic_01" }, body: validDocument } as unknown as Request, res as Response);
+    handleListDocuments({ params: { patientId: "pat_tf_01" } } as unknown as Request, res as Response);
+    const docs = (json.mock.calls[json.mock.calls.length - 1][0] as DocumentRecord[]);
+    expect(docs).toHaveLength(1);
+  });
+
+  it("returns 404 for missing patient documents", () => {
+    handleListDocuments({ params: { patientId: "pat_missing" } } as unknown as Request, res as Response);
+    expect(status).toHaveBeenCalledWith(404);
+  });
+
+  it("gets a specific document by id", () => {
+    handleCreateDocument({ params: { patientId: "pat_tf_01" }, headers: { "x-clinic-id": "clinic_01" }, body: validDocument } as unknown as Request, res as Response);
+    const created = (json.mock.calls[0][0] as DocumentRecord);
+    handleGetDocument({ params: { patientId: "pat_tf_01", documentId: created.id } } as unknown as Request, res as Response);
+    expect(json).toHaveBeenCalledWith(expect.objectContaining({ id: created.id }));
+  });
+
+  it("deletes a document", () => {
+    handleCreateDocument({ params: { patientId: "pat_tf_01" }, headers: { "x-clinic-id": "clinic_01" }, body: validDocument } as unknown as Request, res as Response);
+    const created = (json.mock.calls[0][0] as DocumentRecord);
+    handleDeleteDocument({ params: { patientId: "pat_tf_01", documentId: created.id } } as unknown as Request, res as Response);
+    expect(json).toHaveBeenCalledWith({ ok: true });
+  });
+
+  it("returns 404 when deleting non-existent document", () => {
+    handleDeleteDocument({ params: { patientId: "pat_tf_01", documentId: "doc_nonexistent" } } as unknown as Request, res as Response);
+    expect(status).toHaveBeenCalledWith(404);
+  });
+
+  it("formats file size correctly", () => {
+    expect(formatFileSize(500)).toBe("500 B");
+    expect(formatFileSize(2048)).toBe("2.0 KB");
+    expect(formatFileSize(1048576)).toBe("1.0 MB");
+  });
+
+  it("validates category", () => {
+    expect(validateCategory("lab-report")).toBe(true);
+    expect(validateCategory("imaging")).toBe(true);
+    expect(validateCategory("invalid")).toBe(false);
+  });
+});
+
+export { validDocument as fixtures };

--- a/apps/web/__tests__/documents-ui-flow.test.tsx
+++ b/apps/web/__tests__/documents-ui-flow.test.tsx
@@ -1,0 +1,147 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+
+type UploadStep = "select-file" | "metadata" | "review";
+type DocumentForm = {
+  fileName: string;
+  fileType: string;
+  fileSizeBytes: number;
+  category: string;
+  description: string;
+  tags: string;
+};
+
+function validateStep(step: UploadStep, data: DocumentForm): string[] {
+  const errs: string[] = [];
+  if (step === "select-file") {
+    if (!data.fileName.trim()) errs.push("File name is required");
+    if (!data.fileType.trim()) errs.push("File type is required");
+    if (data.fileSizeBytes <= 0) errs.push("File size is required");
+  }
+  if (step === "metadata") {
+    if (!data.category) errs.push("Category is required");
+  }
+  return errs;
+}
+
+function getNext(current: UploadStep): UploadStep | null {
+  const steps: UploadStep[] = ["select-file", "metadata", "review"];
+  const idx = steps.indexOf(current);
+  return idx < steps.length - 1 ? steps[idx + 1] : null;
+}
+
+function getPrev(current: UploadStep): UploadStep | null {
+  const steps: UploadStep[] = ["select-file", "metadata", "review"];
+  const idx = steps.indexOf(current);
+  return idx > 0 ? steps[idx - 1] : null;
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1048576) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1048576).toFixed(1)} MB`;
+}
+
+const categoryOptions = [
+  { label: "Clinical", value: "clinical" },
+  { label: "Lab Report", value: "lab-report" },
+  { label: "Imaging", value: "imaging" },
+  { label: "Consent Form", value: "consent-form" },
+];
+
+describe("Documents UI Flow", () => {
+  describe("validateStep", () => {
+    const validFile: DocumentForm = {
+      fileName: "report.pdf",
+      fileType: "application/pdf",
+      fileSizeBytes: 102400,
+      category: "lab-report",
+      description: "Test report",
+      tags: "lab, test",
+    };
+
+    it("returns no errors for valid file step", () => {
+      expect(validateStep("select-file", validFile)).toEqual([]);
+    });
+
+    it("requires file name on select-file step", () => {
+      const errors = validateStep("select-file", { ...validFile, fileName: "" });
+      expect(errors).toContain("File name is required");
+    });
+
+    it("requires file type on select-file step", () => {
+      const errors = validateStep("select-file", { ...validFile, fileType: "" });
+      expect(errors).toContain("File type is required");
+    });
+
+    it("requires file size on select-file step", () => {
+      const errors = validateStep("select-file", { ...validFile, fileSizeBytes: 0 });
+      expect(errors).toContain("File size is required");
+    });
+
+    it("requires category on metadata step", () => {
+      const errors = validateStep("metadata", { ...validFile, category: "" });
+      expect(errors).toContain("Category is required");
+    });
+
+    it("returns no errors for valid metadata step", () => {
+      expect(validateStep("metadata", validFile)).toEqual([]);
+    });
+
+    it("returns no errors for review step", () => {
+      expect(validateStep("review", validFile)).toEqual([]);
+    });
+  });
+
+  describe("getNext", () => {
+    it("returns metadata after select-file", () => {
+      expect(getNext("select-file")).toBe("metadata");
+    });
+
+    it("returns review after metadata", () => {
+      expect(getNext("metadata")).toBe("review");
+    });
+
+    it("returns null after review", () => {
+      expect(getNext("review")).toBeNull();
+    });
+  });
+
+  describe("getPrev", () => {
+    it("returns null before select-file", () => {
+      expect(getPrev("select-file")).toBeNull();
+    });
+
+    it("returns select-file from metadata", () => {
+      expect(getPrev("metadata")).toBe("select-file");
+    });
+
+    it("returns metadata from review", () => {
+      expect(getPrev("review")).toBe("metadata");
+    });
+  });
+
+  describe("formatFileSize", () => {
+    it("formats bytes", () => {
+      expect(formatFileSize(500)).toBe("500 B");
+    });
+
+    it("formats kilobytes", () => {
+      expect(formatFileSize(2048)).toBe("2.0 KB");
+    });
+
+    it("formats megabytes", () => {
+      expect(formatFileSize(1048576)).toBe("1.0 MB");
+    });
+  });
+
+  describe("categoryOptions", () => {
+    it("contains expected categories", () => {
+      const values = categoryOptions.map((o) => o.value);
+      expect(values).toContain("clinical");
+      expect(values).toContain("lab-report");
+      expect(values).toContain("imaging");
+      expect(values).toContain("consent-form");
+    });
+  });
+});

--- a/apps/web/app/documents/page.tsx
+++ b/apps/web/app/documents/page.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useState } from "react";
+
+type UploadStep = "select-file" | "metadata" | "review";
+
+type DocumentForm = {
+  fileName: string;
+  fileType: string;
+  fileSizeBytes: number;
+  category: string;
+  description: string;
+  tags: string;
+};
+
+const initialForm: DocumentForm = {
+  fileName: "",
+  fileType: "",
+  fileSizeBytes: 0,
+  category: "",
+  description: "",
+  tags: "",
+};
+
+const categoryOptions = [
+  { label: "Clinical", value: "clinical" },
+  { label: "Administrative", value: "administrative" },
+  { label: "Lab Report", value: "lab-report" },
+  { label: "Imaging", value: "imaging" },
+  { label: "Consent Form", value: "consent-form" },
+  { label: "Other", value: "other" },
+];
+
+const stepLabels: Record<UploadStep, string> = {
+  "select-file": "Select File",
+  metadata: "Metadata",
+  review: "Review & Upload",
+};
+
+const steps: UploadStep[] = ["select-file", "metadata", "review"];
+
+function idx(s: UploadStep): number {
+  return steps.indexOf(s);
+}
+
+function getNext(s: UploadStep): UploadStep | null {
+  const i = idx(s);
+  return i < steps.length - 1 ? steps[i + 1] : null;
+}
+
+function getPrev(s: UploadStep): UploadStep | null {
+  const i = idx(s);
+  return i > 0 ? steps[i - 1] : null;
+}
+
+function validateStep(step: UploadStep, data: DocumentForm): string[] {
+  const errs: string[] = [];
+  if (step === "select-file") {
+    if (!data.fileName.trim()) errs.push("File name is required");
+    if (!data.fileType.trim()) errs.push("File type is required");
+    if (data.fileSizeBytes <= 0) errs.push("File size is required");
+  }
+  if (step === "metadata") {
+    if (!data.category) errs.push("Category is required");
+  }
+  return errs;
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1048576) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1048576).toFixed(1)} MB`;
+}
+
+export default function DocumentsPage() {
+  const [form, setForm] = useState<DocumentForm>(initialForm);
+  const [step, setStep] = useState<UploadStep>("select-file");
+  const [errors, setErrors] = useState<string[]>([]);
+  const [uploaded, setUploaded] = useState(false);
+
+  function update(field: keyof DocumentForm, value: string | number) {
+    setForm((prev) => ({ ...prev, [field]: value }));
+    setErrors([]);
+  }
+
+  function handleNext() {
+    const errs = validateStep(step, form);
+    if (errs.length) { setErrors(errs); return; }
+    const next = getNext(step);
+    if (next) setStep(next);
+  }
+
+  function handlePrev() {
+    const prev = getPrev(step);
+    if (prev) setStep(prev);
+  }
+
+  function handleUpload() {
+    const errs = validateStep("review", form);
+    if (errs.length) { setErrors(errs); return; }
+    setUploaded(true);
+  }
+
+  if (uploaded) {
+    return (
+      <main>
+        <h1>Document Uploaded</h1>
+        <p>Document has been successfully uploaded to the patient records system.</p>
+        <button onClick={() => { setForm(initialForm); setStep("select-file"); setUploaded(false); }}>
+          Upload Another
+        </button>
+      </main>
+    );
+  }
+
+  return (
+    <main>
+      <h1>Documents & Attachments</h1>
+      <nav aria-label="Progress">
+        {steps.map((s) => (
+          <span key={s} data-active={s === step}>{stepLabels[s]}</span>
+        ))}
+      </nav>
+
+      {errors.length > 0 && (
+        <ul aria-label="Errors">
+          {errors.map((e, i) => <li key={i}>{e}</li>)}
+        </ul>
+      )}
+
+      {step === "select-file" && (
+        <section>
+          <label>File Name <input value={form.fileName} onChange={(e) => update("fileName", e.target.value)} /></label>
+          <label>File Type <input value={form.fileType} onChange={(e) => update("fileType", e.target.value)} placeholder="e.g. application/pdf" /></label>
+          <label>File Size (bytes) <input type="number" value={form.fileSizeBytes || ""} onChange={(e) => update("fileSizeBytes", parseInt(e.target.value) || 0)} /></label>
+        </section>
+      )}
+
+      {step === "metadata" && (
+        <section>
+          <label>Category <select value={form.category} onChange={(e) => update("category", e.target.value)}>
+            <option value="">Select category</option>
+            {categoryOptions.map((opt) => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            ))}
+          </select></label>
+          <label>Description <textarea value={form.description} onChange={(e) => update("description", e.target.value)} /></label>
+          <label>Tags (comma-separated) <input value={form.tags} onChange={(e) => update("tags", e.target.value)} placeholder="e.g. lab, blood, routine" /></label>
+        </section>
+      )}
+
+      {step === "review" && (
+        <section>
+          <h2>Review Document</h2>
+          <dl>
+            <dt>File</dt><dd>{form.fileName} ({form.fileType})</dd>
+            <dt>Size</dt><dd>{formatFileSize(form.fileSizeBytes)}</dd>
+            <dt>Category</dt><dd>{form.category}</dd>
+            <dt>Description</dt><dd>{form.description || "—"}</dd>
+            <dt>Tags</dt><dd>{form.tags || "—"}</dd>
+          </dl>
+        </section>
+      )}
+
+      <div>
+        {step !== "select-file" && <button onClick={handlePrev}>Back</button>}
+        {step !== "review" && <button onClick={handleNext}>Next</button>}
+        {step === "review" && <button onClick={handleUpload}>Upload Document</button>}
+      </div>
+    </main>
+  );
+}

--- a/apps/web/lib/documents-contract.ts
+++ b/apps/web/lib/documents-contract.ts
@@ -1,0 +1,102 @@
+export type DocumentDTO = {
+  id: string;
+  patientId: string;
+  clinicId: string;
+  fileName: string;
+  fileType: string;
+  fileSizeBytes: number;
+  category: string;
+  status: string;
+  uploadedBy: string;
+  description: string;
+  tags: string[];
+  storageUrl: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type AttachmentDTO = {
+  id: string;
+  documentId: string;
+  patientId: string;
+  clinicId: string;
+  fileName: string;
+  mimeType: string;
+  fileSizeBytes: number;
+  storageKey: string;
+  uploadedBy: string;
+  createdAt: string;
+};
+
+export type CreateDocumentBody = Omit<DocumentDTO, "id" | "patientId" | "clinicId" | "status" | "createdAt" | "updatedAt">;
+
+export type UpdateDocumentBody = Partial<Omit<DocumentDTO, "id" | "patientId" | "clinicId" | "createdAt" | "updatedAt">>;
+
+export type UploadAttachmentBody = Omit<AttachmentDTO, "id" | "createdAt">;
+
+export type ContractResult<T> =
+  | { ok: true; data: T; status: number }
+  | { ok: false; error: string; status: number };
+
+const BASE_PATH = "/api/v1";
+
+export function documentsContract(baseUrl: string) {
+  const api = baseUrl.replace(/\/+$/, "");
+
+  async function request<T>(
+    method: string,
+    path: string,
+    clinicId: string,
+    body?: unknown,
+  ): Promise<ContractResult<T>> {
+    try {
+      const res = await fetch(`${api}${path}`, {
+        method,
+        headers: {
+          "content-type": "application/json",
+          "x-clinic-id": clinicId,
+        },
+        body: body ? JSON.stringify(body) : undefined,
+      });
+      const data = await res.json();
+      if (!res.ok) return { ok: false, error: data.error || `HTTP ${res.status}`, status: res.status };
+      return { ok: true, data: data as T, status: res.status };
+    } catch (e) {
+      return { ok: false, error: e instanceof Error ? e.message : "Network error", status: 0 };
+    }
+  }
+
+  function list(patientId: string, clinicId: string) {
+    return request<DocumentDTO[]>("GET", `${BASE_PATH}/patients/${encodeURIComponent(patientId)}/documents`, clinicId);
+  }
+
+  function get(patientId: string, documentId: string, clinicId: string) {
+    return request<DocumentDTO>("GET", `${BASE_PATH}/patients/${encodeURIComponent(patientId)}/documents/${encodeURIComponent(documentId)}`, clinicId);
+  }
+
+  function create(patientId: string, clinicId: string, body: CreateDocumentBody) {
+    return request<DocumentDTO>("POST", `${BASE_PATH}/patients/${encodeURIComponent(patientId)}/documents`, clinicId, body);
+  }
+
+  function update(patientId: string, documentId: string, clinicId: string, body: UpdateDocumentBody) {
+    return request<DocumentDTO>("PATCH", `${BASE_PATH}/patients/${encodeURIComponent(patientId)}/documents/${encodeURIComponent(documentId)}`, clinicId, body);
+  }
+
+  function remove(patientId: string, documentId: string, clinicId: string) {
+    return request<{ ok: boolean }>("DELETE", `${BASE_PATH}/patients/${encodeURIComponent(patientId)}/documents/${encodeURIComponent(documentId)}`, clinicId);
+  }
+
+  function listAttachments(patientId: string, documentId: string, clinicId: string) {
+    return request<AttachmentDTO[]>("GET", `${BASE_PATH}/patients/${encodeURIComponent(patientId)}/documents/${encodeURIComponent(documentId)}/attachments`, clinicId);
+  }
+
+  function uploadAttachment(patientId: string, documentId: string, clinicId: string, body: UploadAttachmentBody) {
+    return request<AttachmentDTO>("POST", `${BASE_PATH}/patients/${encodeURIComponent(patientId)}/documents/${encodeURIComponent(documentId)}/attachments`, clinicId, body);
+  }
+
+  function removeAttachment(patientId: string, documentId: string, attachmentId: string, clinicId: string) {
+    return request<{ ok: boolean }>("DELETE", `${BASE_PATH}/patients/${encodeURIComponent(patientId)}/documents/${encodeURIComponent(documentId)}/attachments/${encodeURIComponent(attachmentId)}`, clinicId);
+  }
+
+  return { list, get, create, update, remove, listAttachments, uploadAttachment, removeAttachment };
+}


### PR DESCRIPTION
Implements the documents and attachments API contract, web UI, and test suites.

### Changes
- Add web API contract layer with type-safe fetch wrappers for all document and attachment endpoints
- Add web documents page with multi-step upload workflow (select file → metadata → review)
- Add web UI flow tests covering validation, step navigation, and file size formatting
- Add API tests and fixtures covering document CRUD operations, validation, and file utilities

Closes #721
Closes #726
Closes #729
Closes #730