### PR TITLE
feat(sprint-2): patient records foundation — consent UI flow + service-layer tests (#702, #706, #707, #719)

### DIFF
--- a/apps/mobile/src/__tests__/consent-tests-fixtures.test.ts
+++ b/apps/mobile/src/__tests__/consent-tests-fixtures.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Mobile consent service + contract test fixtures (#707).
+ *
+ * Pairs with the UI-flow fixtures in `ui/consent.ts`. Covers the
+ * network layer (createMobileConsentService) and the typed contract
+ * layer (createMobileConsentContract) end-to-end against a mocked
+ * `global.fetch`, plus reusable mock-response builders other tests
+ * can import.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+import {
+  createMobileConsentService,
+  type ConsentRecord,
+} from "../services/consent";
+import { createMobileConsentContract } from "../contracts/consent";
+
+const mockFetch = vi.fn();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(global as any).fetch = mockFetch;
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+export const consentRecordFixtures = {
+  active: {
+    id: "consent-001",
+    consentType: "data_processing",
+    status: "active",
+    scope: "demographics,clinical_notes",
+    grantedAt: "2026-06-29T10:00:00Z",
+    expiresAt: null,
+  } satisfies ConsentRecord,
+  expiringSoon: {
+    id: "consent-002",
+    consentType: "research",
+    status: "active",
+    scope: "lab_results",
+    grantedAt: "2026-06-01T00:00:00Z",
+    expiresAt: "2026-07-01T00:00:00Z",
+  } satisfies ConsentRecord,
+  revoked: {
+    id: "consent-003",
+    consentType: "communications",
+    status: "revoked",
+    scope: "messaging",
+    grantedAt: "2026-05-01T00:00:00Z",
+    expiresAt: null,
+  } satisfies ConsentRecord,
+};
+
+/** Build a mock `Response` for fetch in a single readable line. */
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+// ── Service-layer tests ───────────────────────────────────────────────────────
+
+describe("createMobileConsentService — fixtures + happy paths (#707)", () => {
+  const svc = createMobileConsentService("http://api.test");
+
+  it("grant() returns the new ConsentRecord on 200", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(200, consentRecordFixtures.active));
+    const result = await svc.grant("patient-1", {
+      consentType: "data_processing",
+      scope: "demographics,clinical_notes",
+    });
+    expect(result.type).toBe("success");
+    if (result.type === "success") {
+      expect(result.data.id).toBe("consent-001");
+      expect(result.data.status).toBe("active");
+    }
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://api.test/api/v1/patients/patient-1/consent",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ "x-clinic-id": "default" }),
+      }),
+    );
+  });
+
+  it("getActive() returns the array of active consents", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse(200, [consentRecordFixtures.active, consentRecordFixtures.expiringSoon]),
+    );
+    const result = await svc.getActive("patient-1");
+    expect(result.type).toBe("success");
+    if (result.type === "success") {
+      expect(result.data).toHaveLength(2);
+      expect(result.data[0].id).toBe("consent-001");
+    }
+  });
+
+  it("revoke() flips status to revoked when the backend returns one", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(200, consentRecordFixtures.revoked));
+    const result = await svc.revoke("patient-1", "consent-003");
+    expect(result.type).toBe("success");
+    if (result.type === "success") {
+      expect(result.data.status).toBe("revoked");
+    }
+  });
+});
+
+describe("createMobileConsentService — error paths (#707)", () => {
+  const svc = createMobileConsentService("http://api.test");
+
+  it("returns error with backend-supplied message on 4xx", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(400, { error: "Invalid scope" }));
+    const result = await svc.grant("patient-1", { consentType: "x", scope: "y" });
+    expect(result.type).toBe("error");
+    if (result.type === "error") expect(result.message).toBe("Invalid scope");
+  });
+
+  it("falls back to a generic HTTP message when body has no error field", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(503, {}));
+    const result = await svc.getActive("patient-1");
+    expect(result.type).toBe("error");
+    if (result.type === "error") expect(result.message).toBe("HTTP 503");
+  });
+
+  it("surfaces network failures as an error result without throwing", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("offline"));
+    const result = await svc.getActive("patient-1");
+    expect(result.type).toBe("error");
+    if (result.type === "error") expect(result.message).toBe("offline");
+  });
+});
+
+// ── Contract-layer tests ──────────────────────────────────────────────────────
+
+describe("createMobileConsentContract — typed wrapper parity (#707)", () => {
+  const contract = createMobileConsentContract("http://api.test");
+
+  it("grant() reaches the same endpoint with the same headers", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(200, consentRecordFixtures.active));
+    const result = await contract.grant("patient-1", {
+      consentType: "data_processing",
+      scope: "demographics",
+    });
+    expect(result.status).toBe("ok");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://api.test/api/v1/patients/patient-1/consent",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("list() hits the GET endpoint and parses an array", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(200, [consentRecordFixtures.active]));
+    const result = await contract.list("patient-1");
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") expect(result.data).toHaveLength(1);
+  });
+
+  it("revoke() POSTs to the /revoke sub-resource", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(200, consentRecordFixtures.revoked));
+    const result = await contract.revoke("patient-1", "consent-003");
+    expect(result.status).toBe("ok");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://api.test/api/v1/patients/patient-1/consent/revoke",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("patient-id is URL-encoded (defends against / in synthetic ids)", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(200, consentRecordFixtures.active));
+    await contract.list("patient/with/slashes");
+    const calledUrl = mockFetch.mock.calls[0][0] as string;
+    expect(calledUrl).toContain("patient%2Fwith%2Fslashes");
+  });
+});

--- a/apps/mobile/src/__tests__/consent-ui-flow.test.ts
+++ b/apps/mobile/src/__tests__/consent-ui-flow.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import {
+  CONSENT_SCOPES,
+  CONSENT_TYPES,
+  createInitialState,
+  fixtures,
+  getSummary,
+  isAllowedScope,
+  isFutureIsoDate,
+  nextStep,
+  prevStep,
+  validateStep,
+} from "../ui/consent";
+
+describe("consent UI flow — state machine (#702)", () => {
+  it("starts on the type step with empty errors", () => {
+    const s = createInitialState("patient-123");
+    expect(s.step).toBe("type");
+    expect(s.draft.patientId).toBe("patient-123");
+    expect(s.errors).toEqual([]);
+  });
+
+  it("walks forward through every step then returns null at the end", () => {
+    expect(nextStep("type")).toBe("scope");
+    expect(nextStep("scope")).toBe("expiry");
+    expect(nextStep("expiry")).toBe("review");
+    expect(nextStep("review")).toBe("confirm");
+    expect(nextStep("confirm")).toBe("done");
+    expect(nextStep("done")).toBeNull();
+  });
+
+  it("walks backward through every step then returns null at the start", () => {
+    expect(prevStep("done")).toBe("confirm");
+    expect(prevStep("confirm")).toBe("review");
+    expect(prevStep("review")).toBe("expiry");
+    expect(prevStep("expiry")).toBe("scope");
+    expect(prevStep("scope")).toBe("type");
+    expect(prevStep("type")).toBeNull();
+  });
+});
+
+describe("consent UI flow — validateStep (#702)", () => {
+  it("requires a patient id at every step", () => {
+    const errs = validateStep("type", {
+      patientId: "",
+      consentType: "data_processing",
+      scopes: [],
+      expiresAt: "",
+    });
+    expect(errs).toContain("Patient is required");
+  });
+
+  it("requires a consent type before leaving the type step", () => {
+    const errs = validateStep("type", fixtures.draftMissingType);
+    expect(errs).toContain("Consent type is required");
+  });
+
+  it("requires at least one scope before leaving the scope step", () => {
+    const errs = validateStep("scope", {
+      patientId: "patient-123",
+      consentType: "data_processing",
+      scopes: [],
+      expiresAt: "",
+    });
+    expect(errs).toContain("At least one scope is required");
+  });
+
+  it("rejects unknown scope tags", () => {
+    const errs = validateStep("scope", fixtures.draftInvalidScope);
+    expect(errs.some((e) => e.includes("not recognized"))).toBe(true);
+  });
+
+  it("accepts an empty expiry (no expiry)", () => {
+    const errs = validateStep("expiry", fixtures.draftValid);
+    expect(errs).toEqual([]);
+  });
+
+  it("rejects an expiry date in the past", () => {
+    const errs = validateStep(
+      "expiry",
+      {
+        ...fixtures.draftValid,
+        expiresAt: "2000-01-01",
+      },
+      new Date("2026-06-30T00:00:00Z"),
+    );
+    expect(errs).toContain("Expiry date must be in the future");
+  });
+
+  it("accepts an expiry date in the future", () => {
+    const errs = validateStep(
+      "expiry",
+      fixtures.draftWithExpiry,
+      new Date("2026-06-30T00:00:00Z"),
+    );
+    expect(errs).toEqual([]);
+  });
+});
+
+describe("consent UI flow — helpers (#702)", () => {
+  it("isAllowedScope only accepts enumerated scopes", () => {
+    expect(isAllowedScope("demographics")).toBe(true);
+    expect(isAllowedScope("billing")).toBe(true);
+    expect(isAllowedScope("not_real")).toBe(false);
+    expect(isAllowedScope("")).toBe(false);
+  });
+
+  it("isFutureIsoDate accepts ISO yyyy-mm-dd in the future", () => {
+    expect(isFutureIsoDate("2030-01-01", new Date("2026-06-30T00:00:00Z"))).toBe(true);
+  });
+
+  it("isFutureIsoDate rejects malformed strings", () => {
+    expect(isFutureIsoDate("01/01/2030")).toBe(false);
+    expect(isFutureIsoDate("yesterday")).toBe(false);
+    expect(isFutureIsoDate("")).toBe(false);
+  });
+
+  it("getSummary renders type, scopes, expiry", () => {
+    expect(getSummary(fixtures.draftValid)).toContain("data_processing");
+    expect(getSummary(fixtures.draftValid)).toContain("demographics");
+    expect(getSummary(fixtures.draftValid)).toContain("no expiry");
+    expect(getSummary(fixtures.draftWithExpiry)).toContain("expires 2030-01-01");
+  });
+
+  it("exposes enumerated CONSENT_TYPES and CONSENT_SCOPES for UI dropdowns", () => {
+    expect(CONSENT_TYPES.length).toBeGreaterThanOrEqual(4);
+    expect(CONSENT_SCOPES.length).toBeGreaterThanOrEqual(5);
+  });
+});

--- a/apps/mobile/src/ui/consent.ts
+++ b/apps/mobile/src/ui/consent.ts
@@ -1,0 +1,185 @@
+/**
+ * Mobile consent-and-privacy UI flow (#702).
+ *
+ * Pure-data state machine for the grant/revoke wizard the mobile shell
+ * renders against. Modeled on `ui/documents.ts` so the two flows share
+ * the same step/next/prev/validate/getSummary shape — anything that
+ * deviates here either belongs in `services/consent.ts` (network) or
+ * `hooks/useConsent.ts` (React state).
+ *
+ * Flow:
+ *   `type` → `scope` → `expiry` → `review` → `confirm` → `done`
+ *
+ * `type`    pick one of the four enumerated consent types
+ * `scope`   pick one or more scope tags (e.g. data sharing categories)
+ * `expiry`  optional expiry date (ISO-8601 yyyy-mm-dd) or "no expiry"
+ * `review`  read-only summary of the grant
+ * `confirm` user taps confirm; service call happens in the next layer
+ * `done`    success state; UI shows the receipt
+ */
+
+export type ConsentType =
+  | "data_processing"
+  | "sharing"
+  | "research"
+  | "communications";
+
+export type ConsentUiStep =
+  | "type"
+  | "scope"
+  | "expiry"
+  | "review"
+  | "confirm"
+  | "done";
+
+export type ConsentDraft = {
+  patientId: string;
+  consentType: ConsentType | "";
+  scopes: string[];
+  /** ISO-8601 date string (yyyy-mm-dd) or empty for no expiry. */
+  expiresAt: string;
+};
+
+export type ConsentStepState = {
+  step: ConsentUiStep;
+  draft: ConsentDraft;
+  errors: string[];
+};
+
+const STEPS: ConsentUiStep[] = [
+  "type",
+  "scope",
+  "expiry",
+  "review",
+  "confirm",
+  "done",
+];
+
+const ALLOWED_TYPES: readonly ConsentType[] = [
+  "data_processing",
+  "sharing",
+  "research",
+  "communications",
+];
+
+const ALLOWED_SCOPES = new Set<string>([
+  "demographics",
+  "clinical_notes",
+  "lab_results",
+  "imaging",
+  "billing",
+  "messaging",
+  "third_party_share",
+]);
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+const emptyDraft: ConsentDraft = {
+  patientId: "",
+  consentType: "",
+  scopes: [],
+  expiresAt: "",
+};
+
+export function createInitialState(patientId = ""): ConsentStepState {
+  return {
+    step: "type",
+    draft: { ...emptyDraft, patientId },
+    errors: [],
+  };
+}
+
+export function nextStep(current: ConsentUiStep): ConsentUiStep | null {
+  const idx = STEPS.indexOf(current);
+  return idx >= 0 && idx < STEPS.length - 1 ? STEPS[idx + 1] : null;
+}
+
+export function prevStep(current: ConsentUiStep): ConsentUiStep | null {
+  const idx = STEPS.indexOf(current);
+  return idx > 0 ? STEPS[idx - 1] : null;
+}
+
+export function isAllowedScope(scope: string): boolean {
+  return ALLOWED_SCOPES.has(scope);
+}
+
+export function isFutureIsoDate(value: string, today = new Date()): boolean {
+  if (!ISO_DATE_RE.test(value)) return false;
+  const target = new Date(`${value}T00:00:00Z`);
+  if (Number.isNaN(target.getTime())) return false;
+  const todayMidnight = new Date(
+    Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()),
+  );
+  return target.getTime() > todayMidnight.getTime();
+}
+
+export function validateStep(
+  step: ConsentUiStep,
+  draft: ConsentDraft,
+  today: Date = new Date(),
+): string[] {
+  const errors: string[] = [];
+  if (!draft.patientId.trim()) errors.push("Patient is required");
+  if (step === "type" || step === "scope" || step === "expiry" || step === "review") {
+    if (!draft.consentType) errors.push("Consent type is required");
+    else if (!ALLOWED_TYPES.includes(draft.consentType as ConsentType)) {
+      errors.push("Consent type is not recognized");
+    }
+  }
+  if (step === "scope" || step === "expiry" || step === "review") {
+    if (draft.scopes.length === 0) errors.push("At least one scope is required");
+    else {
+      for (const s of draft.scopes) {
+        if (!isAllowedScope(s)) {
+          errors.push(`Scope '${s}' is not recognized`);
+          break;
+        }
+      }
+    }
+  }
+  if (step === "expiry" || step === "review") {
+    if (draft.expiresAt && !isFutureIsoDate(draft.expiresAt, today)) {
+      errors.push("Expiry date must be in the future");
+    }
+  }
+  return errors;
+}
+
+export function getSummary(draft: ConsentDraft): string {
+  const expiry = draft.expiresAt ? `expires ${draft.expiresAt}` : "no expiry";
+  const scopes = draft.scopes.length > 0 ? draft.scopes.join(", ") : "(no scopes)";
+  return `${draft.consentType || "(no type)"} · ${scopes} · ${expiry}`;
+}
+
+/** Enumerated consent types — exposed for UI dropdowns. */
+export const CONSENT_TYPES = ALLOWED_TYPES;
+/** Enumerated scope tags — exposed for UI multi-select. */
+export const CONSENT_SCOPES = Array.from(ALLOWED_SCOPES);
+
+/** Fixtures used by tests + Storybook stubs. */
+export const fixtures = {
+  draftValid: {
+    patientId: "patient-123",
+    consentType: "data_processing" as ConsentType,
+    scopes: ["demographics", "clinical_notes"],
+    expiresAt: "",
+  } satisfies ConsentDraft,
+  draftWithExpiry: {
+    patientId: "patient-123",
+    consentType: "research" as ConsentType,
+    scopes: ["lab_results"],
+    expiresAt: "2030-01-01",
+  } satisfies ConsentDraft,
+  draftMissingType: {
+    patientId: "patient-123",
+    consentType: "" as const,
+    scopes: ["demographics"],
+    expiresAt: "",
+  } satisfies ConsentDraft,
+  draftInvalidScope: {
+    patientId: "patient-123",
+    consentType: "sharing" as ConsentType,
+    scopes: ["something_unknown"],
+    expiresAt: "",
+  } satisfies ConsentDraft,
+};

--- a/apps/web/__tests__/consent-tests-fixtures.test.ts
+++ b/apps/web/__tests__/consent-tests-fixtures.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Web consent service-layer fixtures + tests (#706).
+ *
+ * Existing `__tests__/consent.test.tsx` covers the React component
+ * (UI flow + render). This file complements it with the pure service
+ * layer (`lib/consent-service.ts` + `lib/consent-contract.ts`) tests
+ * and the reusable fixtures other consent specs import. Service-layer
+ * tests are deliberately decoupled from React so the API surface can
+ * be unit-tested with a single mocked `global.fetch`.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+import {
+  createWebConsentService,
+  type ConsentRecord,
+} from "../lib/consent-service";
+import { createWebConsentContract } from "../lib/consent-contract";
+
+const mockFetch = vi.fn();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(global as any).fetch = mockFetch;
+
+// ── Reusable fixtures ─────────────────────────────────────────────────────────
+
+export const webConsentFixtures = {
+  activeProcessing: {
+    id: "consent-100",
+    consentType: "data_processing",
+    status: "active",
+    scope: "demographics,clinical_notes",
+    grantedAt: "2026-06-29T10:00:00Z",
+    expiresAt: null,
+  } satisfies ConsentRecord,
+  activeResearch: {
+    id: "consent-101",
+    consentType: "research",
+    status: "active",
+    scope: "lab_results,imaging",
+    grantedAt: "2026-06-15T00:00:00Z",
+    expiresAt: "2026-12-31T00:00:00Z",
+  } satisfies ConsentRecord,
+  revokedSharing: {
+    id: "consent-102",
+    consentType: "sharing",
+    status: "revoked",
+    scope: "third_party_share",
+    grantedAt: "2026-05-01T00:00:00Z",
+    expiresAt: null,
+  } satisfies ConsentRecord,
+};
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+// ── Service-layer tests ───────────────────────────────────────────────────────
+
+describe("createWebConsentService (#706)", () => {
+  const svc = createWebConsentService("http://web.api.test");
+
+  it("grant() posts to the consent endpoint with the clinic header", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(200, webConsentFixtures.activeProcessing));
+    const result = await svc.grant("p1", "clinic_a", {
+      consentType: "data_processing",
+      scope: "demographics",
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data.id).toBe("consent-100");
+    const init = mockFetch.mock.calls[0][1] as RequestInit;
+    expect(init.method).toBe("POST");
+    expect((init.headers as Record<string, string>)["x-clinic-id"]).toBe("clinic_a");
+  });
+
+  it("revoke() sends action=revoke with the consentId in the body", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(200, webConsentFixtures.revokedSharing));
+    const result = await svc.revoke("p1", "clinic_a", "consent-102");
+    expect(result.ok).toBe(true);
+    const init = mockFetch.mock.calls[0][1] as RequestInit;
+    const body = JSON.parse(init.body as string) as { action: string; consentId: string };
+    expect(body.action).toBe("revoke");
+    expect(body.consentId).toBe("consent-102");
+  });
+
+  it("returns error path when fetch throws", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("dns failure"));
+    const result = await svc.grant("p1", "clinic_a", {
+      consentType: "x",
+      scope: "y",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBe("dns failure");
+  });
+
+  it("returns error with backend message on non-2xx", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(409, { error: "Consent already exists" }));
+    const result = await svc.grant("p1", "clinic_a", {
+      consentType: "data_processing",
+      scope: "demographics",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBe("Consent already exists");
+  });
+});
+
+// ── Contract-layer tests ──────────────────────────────────────────────────────
+
+describe("createWebConsentContract (#706)", () => {
+  const contract = createWebConsentContract("http://web.api.test");
+
+  it("list() returns the array of consents on 200", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse(200, [
+        webConsentFixtures.activeProcessing,
+        webConsentFixtures.activeResearch,
+      ]),
+    );
+    const result = await contract.list("p1", "clinic_a");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toHaveLength(2);
+      expect(result.data[1].consentType).toBe("research");
+    }
+  });
+
+  it("encodes patient ids that contain slashes", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(200, []));
+    await contract.list("p1/with/slash", "clinic_a");
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain("p1%2Fwith%2Fslash");
+  });
+});
+
+// ── Cross-layer parity smoke check ────────────────────────────────────────────
+
+describe("service + contract parity (#706)", () => {
+  it("both layers return distinguishable success/failure shapes from a single fetch mock", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(200, webConsentFixtures.activeProcessing));
+    const svc = createWebConsentService("http://web.api.test");
+    const result = await svc.grant("p1", "clinic_a", {
+      consentType: "data_processing",
+      scope: "demographics",
+    });
+    expect(result.ok).toBe(true);
+
+    mockFetch.mockResolvedValueOnce(jsonResponse(500, { error: "boom" }));
+    const contract = createWebConsentContract("http://web.api.test");
+    const failure = await contract.list("p1", "clinic_a");
+    expect(failure.ok).toBe(false);
+  });
+});

--- a/apps/web/__tests__/documents-attachments-service-layer.test.ts
+++ b/apps/web/__tests__/documents-attachments-service-layer.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Service-layer tests for the documents + attachments API (#719).
+ *
+ * The existing `__tests__/documents-ui-flow.test.tsx` covers the React
+ * component side. This file exercises the pure service layer
+ * (`lib/documents-service.ts`) end-to-end against a mocked `global.fetch`,
+ * including:
+ *   - happy-path CRUD on documents
+ *   - list/upload on attachments
+ *   - URL encoding for ids that contain `/`
+ *   - error-result construction for non-2xx and network failures
+ *   - clinic header propagation
+ *   - body-shape validation for create/update
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+import {
+  createDocumentsApi,
+  type AttachmentData,
+  type DocumentData,
+} from "../lib/documents-service";
+
+const mockFetch = vi.fn();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(global as any).fetch = mockFetch;
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+export const documentFixtures = {
+  scan: {
+    id: "doc-001",
+    patientId: "patient-1",
+    clinicId: "clinic_a",
+    fileName: "scan.dcm",
+    fileType: "application/dicom",
+    fileSizeBytes: 2_097_152,
+    category: "imaging",
+    status: "active",
+    uploadedBy: "user-100",
+    description: "Chest CT 2026-06-29",
+    tags: ["ct", "chest"],
+    storageUrl: "s3://lumen/doc-001",
+    createdAt: "2026-06-29T10:00:00Z",
+    updatedAt: "2026-06-29T10:00:00Z",
+  } satisfies DocumentData,
+  labReport: {
+    id: "doc-002",
+    patientId: "patient-1",
+    clinicId: "clinic_a",
+    fileName: "labs.pdf",
+    fileType: "application/pdf",
+    fileSizeBytes: 412_500,
+    category: "lab_results",
+    status: "active",
+    uploadedBy: "user-101",
+    description: "CBC + metabolic panel",
+    tags: ["lab", "blood"],
+    storageUrl: "s3://lumen/doc-002",
+    createdAt: "2026-06-29T11:00:00Z",
+    updatedAt: "2026-06-29T11:00:00Z",
+  } satisfies DocumentData,
+};
+
+export const attachmentFixtures = {
+  primary: {
+    id: "att-001",
+    documentId: "doc-001",
+    patientId: "patient-1",
+    clinicId: "clinic_a",
+    fileName: "scan-page1.png",
+    mimeType: "image/png",
+    fileSizeBytes: 524_288,
+    storageKey: "att-001-key",
+    uploadedBy: "user-100",
+    createdAt: "2026-06-29T10:01:00Z",
+  } satisfies AttachmentData,
+};
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+// ── Documents CRUD ────────────────────────────────────────────────────────────
+
+describe("documents service — list/get (#719)", () => {
+  const api = createDocumentsApi("http://api.test");
+
+  it("listDocuments returns the array on 200", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse(200, [documentFixtures.scan, documentFixtures.labReport]),
+    );
+    const result = await api.listDocuments("patient-1", "clinic_a");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toHaveLength(2);
+      expect(result.data[0].id).toBe("doc-001");
+    }
+  });
+
+  it("listDocuments propagates the clinic header", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(200, []));
+    await api.listDocuments("patient-1", "clinic_a");
+    const init = mockFetch.mock.calls[0][1] as RequestInit;
+    expect((init.headers as Record<string, string>)["x-clinic-id"]).toBe("clinic_a");
+  });
+
+  it("getDocument returns a single record", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(200, documentFixtures.scan));
+    const result = await api.getDocument("patient-1", "doc-001", "clinic_a");
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data.fileName).toBe("scan.dcm");
+  });
+
+  it("getDocument returns an error result on 404", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(404, {}));
+    const result = await api.getDocument("patient-1", "missing", "clinic_a");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBe("HTTP 404");
+  });
+});
+
+describe("documents service — create/update/delete (#719)", () => {
+  const api = createDocumentsApi("http://api.test");
+
+  it("createDocument POSTs the JSON body and returns the new record", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(201, documentFixtures.scan));
+    const result = await api.createDocument("patient-1", "clinic_a", {
+      fileName: "scan.dcm",
+      fileType: "application/dicom",
+      fileSizeBytes: 2_097_152,
+      category: "imaging",
+      uploadedBy: "user-100",
+      description: "Chest CT 2026-06-29",
+      tags: ["ct", "chest"],
+      storageUrl: "s3://lumen/doc-001",
+    });
+    expect(result.ok).toBe(true);
+    const init = mockFetch.mock.calls[0][1] as RequestInit;
+    expect(init.method).toBe("POST");
+    const body = JSON.parse(init.body as string) as { category: string };
+    expect(body.category).toBe("imaging");
+  });
+
+  it("updateDocument PATCHes and accepts a partial body", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse(200, { ...documentFixtures.scan, description: "Updated" }),
+    );
+    const result = await api.updateDocument("patient-1", "doc-001", "clinic_a", {
+      description: "Updated",
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data.description).toBe("Updated");
+    const init = mockFetch.mock.calls[0][1] as RequestInit;
+    expect(init.method).toBe("PATCH");
+  });
+
+  it("deleteDocument returns true on 200", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(200, {}));
+    const result = await api.deleteDocument("patient-1", "doc-001", "clinic_a");
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data).toBe(true);
+  });
+
+  it("deleteDocument surfaces 403 as a typed error", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(403, {}));
+    const result = await api.deleteDocument("patient-1", "doc-001", "clinic_a");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBe("HTTP 403");
+  });
+});
+
+// ── Attachments ───────────────────────────────────────────────────────────────
+
+describe("documents service — attachments (#719)", () => {
+  const api = createDocumentsApi("http://api.test");
+
+  it("listAttachments hits the document's attachments sub-resource", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(200, [attachmentFixtures.primary]));
+    const result = await api.listAttachments("patient-1", "doc-001", "clinic_a");
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data[0].documentId).toBe("doc-001");
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain("/documents/doc-001/attachments");
+  });
+
+  it("uploadAttachment POSTs and round-trips the new attachment", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(201, attachmentFixtures.primary));
+    const result = await api.uploadAttachment("patient-1", "doc-001", "clinic_a", {
+      documentId: "doc-001",
+      patientId: "patient-1",
+      clinicId: "clinic_a",
+      fileName: "scan-page1.png",
+      mimeType: "image/png",
+      fileSizeBytes: 524_288,
+      storageKey: "att-001-key",
+      uploadedBy: "user-100",
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data.id).toBe("att-001");
+    const init = mockFetch.mock.calls[0][1] as RequestInit;
+    expect(init.method).toBe("POST");
+  });
+
+  it("uploadAttachment surfaces a network error without throwing", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("connection reset"));
+    const result = await api.uploadAttachment("patient-1", "doc-001", "clinic_a", {
+      documentId: "doc-001",
+      patientId: "patient-1",
+      clinicId: "clinic_a",
+      fileName: "x.png",
+      mimeType: "image/png",
+      fileSizeBytes: 1,
+      storageKey: "k",
+      uploadedBy: "u",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBe("connection reset");
+  });
+});
+
+// ── Cross-cutting behavior ────────────────────────────────────────────────────
+
+describe("documents service — cross-cutting (#719)", () => {
+  it("baseUrl override wins over the env default", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(200, []));
+    const api = createDocumentsApi("http://override.example");
+    await api.listDocuments("p1", "c1");
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url.startsWith("http://override.example/")).toBe(true);
+  });
+
+  it("Content-Type header is set on write requests", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(200, documentFixtures.scan));
+    const api = createDocumentsApi("http://api.test");
+    await api.updateDocument("p1", "doc-001", "c1", { tags: ["x"] });
+    const init = mockFetch.mock.calls[0][1] as RequestInit;
+    expect((init.headers as Record<string, string>)["Content-Type"]).toBe("application/json");
+  });
+});


### PR DESCRIPTION
## Summary
Four Sprint-2 \"patient records foundation\" tasks in one PR — mobile consent UI flow, mobile+web tests & fixtures around consent, and service-layer tests for documents/attachments.

### Issue #702 — feat(mobile): consent and privacy / UI flow
New `apps/mobile/src/ui/consent.ts`:
- Pure-data state machine for the consent grant wizard, modeled on the existing `ui/documents.ts` pattern.
- Steps: **type → scope → expiry → review → confirm → done**.
- Exports `createInitialState`, `nextStep`, `prevStep`, `validateStep(step, draft, today)`, `getSummary`, helpers (`isAllowedScope`, `isFutureIsoDate`), enumerated `CONSENT_TYPES` / `CONSENT_SCOPES` for UI dropdowns, and a shared `fixtures` object.
- Framework-agnostic — no React imports. The mobile shell wires it.

### Issue #707 — feat(mobile): consent and privacy / tests and fixtures
- New `apps/mobile/src/__tests__/consent-ui-flow.test.ts` — **14 tests** covering the state machine transitions, `validateStep` guards (patient id, type, scope allowlist, future-only expiry), helper predicates, and the enumerated dropdown lengths.
- New `apps/mobile/src/__tests__/consent-tests-fixtures.test.ts` — **11 tests** + reusable fixtures (`active`, `expiringSoon`, `revoked`) exercising `createMobileConsentService` and `createMobileConsentContract` end-to-end against a mocked `global.fetch`: grant / list / revoke happy paths, error paths (4xx with backend message, 5xx fallback, network failure), and URL encoding for patient ids with slashes.

### Issue #706 — feat(web): consent and privacy / tests and fixtures
- New `apps/web/__tests__/consent-tests-fixtures.test.ts` — **8 tests** + three reusable fixtures (`activeProcessing`, `activeResearch`, `revokedSharing`) other consent specs can import. Exercises `createWebConsentService` (grant, revoke, error paths) and `createWebConsentContract` (list, URL encoding). Complements the existing component-level `__tests__/consent.test.tsx`.

### Issue #719 — test: documents and attachments / service layer
- New `apps/web/__tests__/documents-attachments-service-layer.test.ts` — **12 tests** for `createDocumentsApi` covering:
  - documents CRUD (list / get / create / update / delete)
  - attachments (list / upload)
  - error result construction on 4xx / 5xx / network failure
  - clinic header propagation
  - `baseUrl` override winning over the env default
  - `Content-Type: application/json` on write requests
- Reusable `documentFixtures` (scan, labReport) and `attachmentFixtures` exports.

## Verification
```bash
vitest run __tests__/consent-tests-fixtures.test.ts \\
          __tests__/documents-attachments-service-layer.test.ts   # ✅ 20/20 web
vitest run --root apps/mobile \\
          apps/mobile/src/__tests__/consent-ui-flow.test.ts \\
          apps/mobile/src/__tests__/consent-tests-fixtures.test.ts  # ✅ 25/25 mobile
turbo run typecheck                                                  # no new errors
```

**45/45 new tests pass.** The pre-existing `turbo typecheck` failures (in `mobile/src/contracts/documents.ts`, `mobile/src/hooks/use{Consent,Demographics}.ts`, `mobile/src/services/{chart-timeline,consent,demographics,documents}.ts`, `apps/web/__tests__/clinic-settings.test.tsx`, and `apps/web/__tests__/patient-registration.test.tsx`) are present on `main` and unrelated to this change.

Closes #702
Closes #706
Closes #707
Closes #719