### PR TITLE
feat(audit): add SHA-256 hashing for audit entries 

### DIFF
--- a/apps/api/src/modules/audit/services/audit.service.ts
+++ b/apps/api/src/modules/audit/services/audit.service.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "crypto";
-import type { AuditAction, AuditEntry, AuditQuery, UserRole } from "@lumen/types";
+import { hashAuditEntry, type AuditAction, type AuditEntry, type AuditQuery, type UserRole } from "@lumen/types";
 import { auditStore } from "../repositories/audit.repository.js";
 
 export type RecordAuditParams = {
@@ -16,7 +16,7 @@ export type RecordAuditParams = {
 };
 
 export function recordAudit(params: RecordAuditParams): AuditEntry {
-  const entry: AuditEntry = {
+  const unhashed = {
     auditId: randomUUID(),
     clinicId: params.clinicId,
     action: params.action,
@@ -29,6 +29,10 @@ export function recordAudit(params: RecordAuditParams): AuditEntry {
     ipAddress: params.ipAddress,
     userAgent: params.userAgent,
     createdAt: new Date().toISOString(),
+  };
+  const entry: AuditEntry = {
+    ...unhashed,
+    sha256Hash: hashAuditEntry(unhashed),
   };
 
   return auditStore.save(entry);

--- a/apps/stellar-service/package.json
+++ b/apps/stellar-service/package.json
@@ -7,15 +7,18 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
     "lint": "node -e \"console.log('stellar lint: add stronger checks in milestone work')\""
   },
   "dependencies": {
     "@lumen/config": "^0.1.0",
+    "@lumen/types": "^0.1.0",
     "@stellar/stellar-sdk": "^14.6.1"
   },
   "devDependencies": {
     "@types/node": "^24.10.1",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.7"
   }
 }

--- a/apps/stellar-service/src/__tests__/hashing.test.ts
+++ b/apps/stellar-service/src/__tests__/hashing.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { canonicalize, sha256Hash } from "../hashing.js";
+
+describe("stellar-service hashing module (re-exported canonicalization)", () => {
+  it("is stable across key insertion order", () => {
+    expect(canonicalize({ a: 1, b: 2 })).toBe(canonicalize({ b: 2, a: 1 }));
+  });
+
+  it("treats undefined fields the same as missing fields", () => {
+    expect(canonicalize({ a: 1, b: undefined })).toBe(canonicalize({ a: 1 }));
+  });
+
+  it("treats null as distinct from missing", () => {
+    expect(canonicalize({ a: 1, b: null })).not.toBe(canonicalize({ a: 1 }));
+  });
+
+  it("sorts keys in nested objects regardless of depth", () => {
+    const a = { outer: { z: 1, inner: { y: 1, x: 2 } } };
+    const b = { outer: { inner: { x: 2, y: 1 }, z: 1 } };
+    expect(canonicalize(a)).toBe(canonicalize(b));
+  });
+
+  it("produces a deterministic sha256 hex digest usable as a Stellar memo hash source", () => {
+    const digest = sha256Hash({ auditId: "a-1", action: "staff.role_changed" });
+    expect(digest).toMatch(/^[0-9a-f]{64}$/);
+    expect(sha256Hash({ auditId: "a-1", action: "staff.role_changed" })).toBe(digest);
+  });
+
+  it("produces a different digest for a semantically different payload", () => {
+    const a = sha256Hash({ before: { role: "clinician" }, after: { role: "admin" } });
+    const b = sha256Hash({ before: { role: "clinician" }, after: { role: "cashier" } });
+    expect(a).not.toBe(b);
+  });
+});

--- a/apps/stellar-service/src/client.ts
+++ b/apps/stellar-service/src/client.ts
@@ -1,0 +1,35 @@
+import { Horizon } from "@stellar/stellar-sdk";
+import type { StellarNetworkConfig } from "./config.js";
+
+/**
+ * Thin, typed wrapper around `Horizon.Server`. Keeps the raw SDK client out
+ * of the rest of the codebase so call sites depend on a narrow, testable
+ * surface instead of the full Horizon API.
+ */
+export class StellarClient {
+  private readonly server: Horizon.Server;
+  readonly network: StellarNetworkConfig;
+
+  constructor(network: StellarNetworkConfig) {
+    this.network = network;
+    this.server = new Horizon.Server(network.horizonUrl);
+  }
+
+  async isHealthy(): Promise<boolean> {
+    try {
+      await this.server.feeStats();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async loadAccount(publicKey: string): Promise<Horizon.AccountResponse> {
+    return this.server.loadAccount(publicKey);
+  }
+
+  /** Escape hatch for calls not yet wrapped by this client. */
+  raw(): Horizon.Server {
+    return this.server;
+  }
+}

--- a/apps/stellar-service/src/config.ts
+++ b/apps/stellar-service/src/config.ts
@@ -1,0 +1,32 @@
+import { Keypair, Networks } from "@stellar/stellar-sdk";
+import { serverConfig } from "@lumen/config";
+
+export type StellarNetworkConfig = {
+  network: string;
+  networkPassphrase: string;
+  horizonUrl: string;
+};
+
+export function loadNetworkConfig(): StellarNetworkConfig {
+  return {
+    network: serverConfig.stellarNetwork,
+    networkPassphrase:
+      serverConfig.stellarNetwork === "mainnet" ? Networks.PUBLIC : Networks.TESTNET,
+    horizonUrl: serverConfig.stellarHorizonUrl,
+  };
+}
+
+/**
+ * Loads the anchoring account's keypair from `STELLAR_ANCHOR_SECRET`.
+ * Throws if the env var is missing or not a valid Stellar secret seed.
+ * No transactions are signed with this yet — the loader exists so the
+ * anchoring write path (a later issue) has a single, tested place to get
+ * a keypair from.
+ */
+export function loadAnchorKeypair(): Keypair {
+  const secret = process.env.STELLAR_ANCHOR_SECRET?.trim();
+  if (!secret) {
+    throw new Error("[stellar-service] Missing required environment variable: STELLAR_ANCHOR_SECRET");
+  }
+  return Keypair.fromSecret(secret);
+}

--- a/apps/stellar-service/src/hashing.ts
+++ b/apps/stellar-service/src/hashing.ts
@@ -1,0 +1,1 @@
+export { canonicalize, sha256Hash, hashAuditEntry } from "@lumen/types";

--- a/apps/stellar-service/src/index.ts
+++ b/apps/stellar-service/src/index.ts
@@ -1,23 +1,27 @@
-import { Horizon, Networks } from "@stellar/stellar-sdk";
-import { serverConfig } from "@lumen/config";
+import { loadNetworkConfig } from "./config.js";
+import { StellarClient } from "./client.js";
 
-const networkPassphrase =
-  serverConfig.stellarNetwork === "mainnet" ? Networks.PUBLIC : Networks.TESTNET;
-
-const server = new Horizon.Server(serverConfig.stellarHorizonUrl);
+export { loadNetworkConfig, loadAnchorKeypair } from "./config.js";
+export type { StellarNetworkConfig } from "./config.js";
+export { StellarClient } from "./client.js";
+export { canonicalize, sha256Hash, hashAuditEntry } from "./hashing.js";
 
 async function main() {
-  console.log("LumenHealth Stellar service starter");
-  console.log(`Network: ${serverConfig.stellarNetwork}`);
-  console.log(`Passphrase: ${networkPassphrase}`);
+  const network = loadNetworkConfig();
+  const client = new StellarClient(network);
 
-  try {
-    await server.feeStats();
+  console.log("LumenHealth Stellar service starter");
+  console.log(`Network: ${network.network}`);
+  console.log(`Passphrase: ${network.networkPassphrase}`);
+
+  const healthy = await client.isHealthy();
+  if (healthy) {
     console.log("Horizon diagnostics reachable");
-  } catch (error) {
+  } else {
     console.error("Unable to reach Horizon diagnostics");
-    console.error(error);
   }
 }
 
-void main();
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  void main();
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -293,12 +293,14 @@
       "version": "0.1.0",
       "dependencies": {
         "@lumen/config": "^0.1.0",
+        "@lumen/types": "^0.1.0",
         "@stellar/stellar-sdk": "^14.6.1"
       },
       "devDependencies": {
         "@types/node": "^24.10.1",
         "tsx": "^4.21.0",
-        "typescript": "^5.9.3"
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.7"
       }
     },
     "apps/web": {

--- a/packages/types/src/__tests__/hashing.test.ts
+++ b/packages/types/src/__tests__/hashing.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { canonicalize, sha256Hash, hashAuditEntry } from "../hashing.js";
+import type { HashableAuditEntry } from "../audit.js";
+
+describe("canonicalize", () => {
+  it("produces the same output regardless of key insertion order", () => {
+    const a = { b: 1, a: 2, c: 3 };
+    const b = { c: 3, a: 2, b: 1 };
+    expect(canonicalize(a)).toBe(canonicalize(b));
+  });
+
+  it("treats an explicit undefined field the same as a missing field", () => {
+    const withUndefined = { a: 1, b: undefined };
+    const missing = { a: 1 };
+    expect(canonicalize(withUndefined)).toBe(canonicalize(missing));
+  });
+
+  it("preserves null as distinct from undefined/missing", () => {
+    const withNull = { a: 1, b: null };
+    const missing = { a: 1 };
+    expect(canonicalize(withNull)).not.toBe(canonicalize(missing));
+  });
+
+  it("sorts keys recursively in nested objects", () => {
+    const a = { outer: { z: 1, y: { n: 2, m: 3 } } };
+    const b = { outer: { y: { m: 3, n: 2 }, z: 1 } };
+    expect(canonicalize(a)).toBe(canonicalize(b));
+  });
+
+  it("preserves array element order", () => {
+    const a = { list: [1, 2, 3] };
+    const b = { list: [3, 2, 1] };
+    expect(canonicalize(a)).not.toBe(canonicalize(b));
+  });
+
+  it("distinguishes objects that differ only in one field's value", () => {
+    const a = { x: 1 };
+    const b = { x: 2 };
+    expect(canonicalize(a)).not.toBe(canonicalize(b));
+  });
+});
+
+describe("sha256Hash", () => {
+  it("is deterministic for semantically identical values", () => {
+    const a = { role: "clinician", changedAt: "2026-01-01T00:00:00.000Z", note: undefined };
+    const b = { changedAt: "2026-01-01T00:00:00.000Z", role: "clinician" };
+    expect(sha256Hash(a)).toBe(sha256Hash(b));
+  });
+
+  it("changes when any field value changes", () => {
+    const before = { role: "clinician" };
+    const after = { role: "admin" };
+    expect(sha256Hash(before)).not.toBe(sha256Hash(after));
+  });
+
+  it("returns a 64-character hex digest", () => {
+    const digest = sha256Hash({ a: 1 });
+    expect(digest).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe("hashAuditEntry", () => {
+  const base: HashableAuditEntry = {
+    auditId: "a-1",
+    clinicId: "c-1",
+    action: "staff.role_changed",
+    actorId: "u-1",
+    actorRole: "owner",
+    targetId: "u-2",
+    targetType: "staff",
+    before: { role: "clinician" },
+    after: { role: "admin" },
+    createdAt: "2026-01-01T00:00:00.000Z",
+  };
+
+  it("is stable across two semantically identical entries", () => {
+    const clone: HashableAuditEntry = JSON.parse(JSON.stringify(base));
+    expect(hashAuditEntry(base)).toBe(hashAuditEntry(clone));
+  });
+
+  it("is unaffected by explicit undefined optional fields", () => {
+    const withExplicitUndefined: HashableAuditEntry = {
+      ...base,
+      ipAddress: undefined,
+      userAgent: undefined,
+    };
+    expect(hashAuditEntry(base)).toBe(hashAuditEntry(withExplicitUndefined));
+  });
+
+  it("changes when the `before` field changes", () => {
+    const tampered: HashableAuditEntry = { ...base, before: { role: "admin" } };
+    expect(hashAuditEntry(base)).not.toBe(hashAuditEntry(tampered));
+  });
+
+  it("changes when the `after` field changes", () => {
+    const tampered: HashableAuditEntry = { ...base, after: { role: "cashier" } };
+    expect(hashAuditEntry(base)).not.toBe(hashAuditEntry(tampered));
+  });
+
+  it("changes when any top-level field changes", () => {
+    const tampered: HashableAuditEntry = { ...base, actorId: "u-999" };
+    expect(hashAuditEntry(base)).not.toBe(hashAuditEntry(tampered));
+  });
+});

--- a/packages/types/src/__tests__/types.test.ts
+++ b/packages/types/src/__tests__/types.test.ts
@@ -75,6 +75,7 @@ describe("@lumen/types — compile-time shape checks", () => {
       before: { role: "clinician" },
       after: { role: "admin" },
       createdAt: new Date().toISOString(),
+      sha256Hash: "a".repeat(64),
     } satisfies AuditEntry;
 
     void _entry;

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -25,7 +25,17 @@ export type AuditEntry = {
   ipAddress?: string;
   userAgent?: string;
   createdAt: string;
+  /**
+   * SHA-256 hex digest over the canonical serialization of every other
+   * field on this entry (see `hashAuditEntry` in `./hashing.js`). Lets a
+   * verifier detect any post-write tampering with `before`/`after` or any
+   * other field.
+   */
+  sha256Hash: string;
 };
+
+/** Fields hashed to derive `AuditEntry.sha256Hash`. */
+export type HashableAuditEntry = Omit<AuditEntry, "sha256Hash">;
 
 export type AuditQuery = {
   clinicId: string;

--- a/packages/types/src/hashing.ts
+++ b/packages/types/src/hashing.ts
@@ -1,0 +1,53 @@
+import { createHash } from "node:crypto";
+import type { HashableAuditEntry } from "./audit.js";
+
+/**
+ * Canonicalizes a value into a stable JSON string: object keys are sorted
+ * recursively and `undefined` values are dropped (so a field that is
+ * `undefined` serializes identically to a field that is missing entirely).
+ * Arrays preserve their order. `null` is preserved as-is (distinct from
+ * `undefined`/missing).
+ */
+export function canonicalize(value: unknown): string {
+  return stringify(value);
+}
+
+function stringify(value: unknown): string {
+  if (value === undefined) {
+    // Callers at the top level get the literal string "undefined" from
+    // JSON.stringify(undefined); canonicalize() should never be called with
+    // undefined as the root value in practice, but keep this defined.
+    return "undefined";
+  }
+
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => (item === undefined ? "null" : stringify(item))).join(",")}]`;
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+
+  const body = entries.map(([k, v]) => `${JSON.stringify(k)}:${stringify(v)}`).join(",");
+  return `{${body}}`;
+}
+
+/**
+ * Computes a deterministic SHA-256 hex digest over the canonical
+ * serialization of `value`.
+ */
+export function sha256Hash(value: unknown): string {
+  return createHash("sha256").update(canonicalize(value)).digest("hex");
+}
+
+/**
+ * Derives the deterministic `sha256Hash` for an `AuditEntry`, hashing every
+ * field except `sha256Hash` itself.
+ */
+export function hashAuditEntry(entry: HashableAuditEntry): string {
+  return sha256Hash(entry);
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -2,6 +2,7 @@ export * from "./auth.js";
 export * from "./clinic.js";
 export * from "./staff.js";
 export * from "./audit.js";
+export * from "./hashing.js";
 
 export type PaymentIntent = {
   id: string;


### PR DESCRIPTION
- Introduced `sha256Hash` and `hashAuditEntry` functions for secure hashing.
- Updated `AuditEntry` type to include `sha256Hash` field.
- Modified `recordAudit` function to compute and store the hash.
- Added tests for hashing functionality in both `types` and `stellar-service` modules.
- Created `StellarClient` and `loadNetworkConfig` for improved Stellar service integration.

## Summary

- 

## Related Issues

- 

## Contract Change

- [ ] No public contract changes
- [ ] Additive contract change
- [ ] Compatibility-sensitive contract change
- [ ] Breaking contract change

If any contract changed, include:

- impacted package(s) or endpoint(s):
- affected consumers:
- fallback/deprecation plan:
- changelog entry reference:

## Privacy / Compliance Review

- [ ] No PHI handling changes
- [ ] Logging remains redacted
- [ ] Test fixtures remain synthetic and privacy-safe

## Validation

- [ ] Architecture checks
- [ ] Relevant tests
- [ ] Manual flow verification

## Maintainer Notes

- ADR/RFC required:
- rollout or migration notes:

closes #804 