### PR TITLE
feat(records): patient record document access control & data model spec

### DIFF
--- a/apps/api/src/modules/documents/repositories/in-memory-document.repository.ts
+++ b/apps/api/src/modules/documents/repositories/in-memory-document.repository.ts
@@ -1,0 +1,14 @@
+import type { DocumentAccessControl, DocumentStoragePolicy } from '@qyou/shared';
+
+export class InMemoryDocumentRepository {
+  private readonly accessPolicies: Map<string, DocumentAccessControl> = new Map();
+
+  public async setAccessControl(policy: DocumentAccessControl): Promise<DocumentAccessControl> {
+    this.accessPolicies.set(policy.documentId, policy);
+    return policy;
+  }
+
+  public async getAccessControl(documentId: string): Promise<DocumentAccessControl | null> {
+    return this.accessPolicies.get(documentId) ?? null;
+  }
+}

--- a/apps/web/src/components/DocumentMetadataCard.tsx
+++ b/apps/web/src/components/DocumentMetadataCard.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import type { AccessLevel } from '@qyou/shared';
+
+interface DocumentMetadataCardProps {
+  accessLevel?: AccessLevel;
+  retentionDays?: number;
+  encrypted?: boolean;
+}
+
+export function DocumentMetadataCard({
+  accessLevel = 'restricted_practitioner',
+  retentionDays = 365,
+  encrypted = true,
+}: DocumentMetadataCardProps) {
+  return (
+    <div style={{ padding: '12px 16px', background: '#f1f5f9', borderRadius: '6px', fontSize: '13px' }}>
+      <div style={{ fontWeight: 'bold', color: '#334155' }}>Access Level: {accessLevel.replace('_', ' ')}</div>
+      <div style={{ color: '#64748b', marginTop: '4px' }}>Retention: {retentionDays} days | Encryption: {encrypted ? 'AES-256 Enabled' : 'None'}</div>
+    </div>
+  );
+}

--- a/docs/patient-records-data-model-spec.md
+++ b/docs/patient-records-data-model-spec.md
@@ -1,0 +1,13 @@
+# Patient Records Data Model Specification
+
+This document details the data model specifications for patient document storage policies, access control levels, and metadata schemas.
+
+## Data Model & Repository
+
+1. **Access Control & Storage Policies**:
+   - `DocumentAccessControl`, `DocumentStoragePolicy`, and `AccessLevel` interfaces defined in `@qyou/shared`.
+   - Zod schemas `documentAccessControlSchema` and `storagePolicySchema`.
+
+2. **Repository & UI Components**:
+   - `InMemoryDocumentRepository`: Manages in-memory storage of document access policies.
+   - `DocumentMetadataCard`: React component displaying document retention and security attributes.

--- a/packages/shared/src/types/document-data-model.types.ts
+++ b/packages/shared/src/types/document-data-model.types.ts
@@ -1,0 +1,19 @@
+export type AccessLevel = 'public_read' | 'restricted_practitioner' | 'confidential_patient';
+
+export interface DocumentStoragePolicy {
+  retentionDays: number;
+  encryptedAtRest: boolean;
+  backupRegion: string;
+}
+
+export interface DocumentAccessControl {
+  documentId: string;
+  accessLevel: AccessLevel;
+  authorizedRoles: string[];
+}
+
+export interface PatientRecordHeader {
+  patientId: string;
+  totalDocumentsCount: number;
+  lastUpdatedTimestamp: string;
+}

--- a/packages/shared/src/validation/document-data-model.schemas.ts
+++ b/packages/shared/src/validation/document-data-model.schemas.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+export const accessLevelSchema = z.enum(['public_read', 'restricted_practitioner', 'confidential_patient']);
+
+export const storagePolicySchema = z.object({
+  retentionDays: z.number().int().positive().default(365),
+  encryptedAtRest: z.boolean().default(true),
+  backupRegion: z.string().default('us-east-1'),
+});
+
+export const documentAccessControlSchema = z.object({
+  documentId: z.string().min(1, 'Document ID is required.'),
+  accessLevel: accessLevelSchema,
+  authorizedRoles: z.array(z.string()).min(1, 'At least one role must be specified.'),
+});
+
+export type DocumentAccessControlInput = z.infer<typeof documentAccessControlSchema>;
+export type StoragePolicyInput = z.infer<typeof storagePolicySchema>;


### PR DESCRIPTION
Refined the patient record document data models, access control schemas, and storage retention policies.

Overview:
- Built InMemoryDocumentRepository in apps/api for document access control management
- Added DocumentMetadataCard UI component in apps/web/src/components
- Defined documentAccessControlSchema & storagePolicySchema in @qyou/shared
- Formulated specification guidelines in docs/patient-records-data-model-spec.md

close #918
close #917
close #916
close #915