### PR TITLE
feat(api): patient record document test fixtures & schema validation

### DIFF
--- a/apps/api/src/fixtures/patient-documents-api.fixture.ts
+++ b/apps/api/src/fixtures/patient-documents-api.fixture.ts
@@ -1,0 +1,24 @@
+import type { ApiDocumentFixture } from '@qyou/shared';
+
+export const mockApiDocumentFixtures: ApiDocumentFixture[] = [
+  {
+    fixtureId: 'fix_lab_001',
+    description: 'Valid Lab Report Attachment Seed',
+    mockAttachment: {
+      attachmentId: 'att_9910',
+      originalFileName: 'blood_test_results.pdf',
+      storagePath: '/mock/storage/att_9910.pdf',
+      status: 'valid',
+    },
+  },
+  {
+    fixtureId: 'fix_imaging_002',
+    description: 'Chest X-Ray DICOM Attachment Seed',
+    mockAttachment: {
+      attachmentId: 'att_9911',
+      originalFileName: 'chest_xray.dcm',
+      storagePath: '/mock/storage/att_9911.dcm',
+      status: 'valid',
+    },
+  },
+];

--- a/apps/api/src/modules/documents/validators/document-fixture.validator.ts
+++ b/apps/api/src/modules/documents/validators/document-fixture.validator.ts
@@ -1,0 +1,8 @@
+import {
+  apiDocumentFixtureSchema,
+  type ApiDocumentFixtureInput,
+} from '@qyou/shared';
+
+export function validateApiDocumentFixture(data: unknown) {
+  return apiDocumentFixtureSchema.safeParse(data);
+}

--- a/docs/patient-records-api-fixtures-spec.md
+++ b/docs/patient-records-api-fixtures-spec.md
@@ -1,0 +1,12 @@
+# Patient Records API Fixtures & Test Foundation
+
+This document outlines the API test fixture structure, mock document attachment seeds, and validation rules for patient records integration tests.
+
+## API Test Fixtures & Validation
+
+1. **API Seed Data & Validator**:
+   - `apps/api/src/fixtures/patient-documents-api.fixture.ts`: Mock API attachment seeds.
+   - `apps/api/src/modules/documents/validators/document-fixture.validator.ts`: Safe parsing for test fixture payloads.
+
+2. **Validation Schemas & Interfaces**:
+   - `apiDocumentFixtureSchema` and `MockAttachmentResponse` defined in `@qyou/shared`.

--- a/packages/shared/src/types/document-api-fixtures.types.ts
+++ b/packages/shared/src/types/document-api-fixtures.types.ts
@@ -1,0 +1,17 @@
+export interface MockAttachmentResponse {
+  attachmentId: string;
+  originalFileName: string;
+  storagePath: string;
+  status: 'valid' | 'corrupted' | 'quarantined';
+}
+
+export interface ApiDocumentFixture {
+  fixtureId: string;
+  description: string;
+  mockAttachment: MockAttachmentResponse;
+}
+
+export interface DocumentTestEnvironmentConfig {
+  useMockStorage: boolean;
+  bypassVirusScanInTests: boolean;
+}

--- a/packages/shared/src/validation/document-api-fixtures.schemas.ts
+++ b/packages/shared/src/validation/document-api-fixtures.schemas.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+export const mockAttachmentResponseSchema = z.object({
+  attachmentId: z.string().min(1, 'Attachment ID is required.'),
+  originalFileName: z.string().min(1, 'File name is required.'),
+  storagePath: z.string().min(1, 'Storage path is required.'),
+  status: z.enum(['valid', 'corrupted', 'quarantined']),
+});
+
+export const apiDocumentFixtureSchema = z.object({
+  fixtureId: z.string().min(1),
+  description: z.string().min(1),
+  mockAttachment: mockAttachmentResponseSchema,
+});
+
+export type ApiDocumentFixtureInput = z.infer<typeof apiDocumentFixtureSchema>;


### PR DESCRIPTION
Added API test fixtures and validation helpers for patient record document attachment integration testing.

Key additions:
- Created mock API document seeds in apps/api/src/fixtures/patient-documents-api.fixture.ts
- Built validateApiDocumentFixture helper in apps/api/src/modules/documents/validators
- Defined apiDocumentFixtureSchema & mockAttachmentResponseSchema in @qyou/shared
- Documented API test fixture specifications in docs/patient-records-api-fixtures-spec.md

Resolves #934
Resolves #933
Resolves #932
Resolves #931