### PR TITLE
feat(records): patient chart timeline test fixtures & seed schemas

### DIFF
--- a/apps/api/src/fixtures/chart-timeline-api.fixture.ts
+++ b/apps/api/src/fixtures/chart-timeline-api.fixture.ts
@@ -1,0 +1,14 @@
+import type { TimelineFixtureSeed } from '@qyou/shared';
+
+export const mockApiChartTimelineFixture: TimelineFixtureSeed = {
+  seedId: 'api_seed_002',
+  patientId: 'patient_101',
+  mockEvents: [
+    {
+      eventId: 'evt_301',
+      category: 'lab_result',
+      title: 'Lipid Panel Laboratory Results',
+      timestamp: '2026-07-25T11:15:00Z',
+    },
+  ],
+};

--- a/apps/web/src/fixtures/chart-timeline.fixture.ts
+++ b/apps/web/src/fixtures/chart-timeline.fixture.ts
@@ -1,0 +1,20 @@
+import type { TimelineFixtureSeed } from '@qyou/shared';
+
+export const mockWebChartTimelineFixture: TimelineFixtureSeed = {
+  seedId: 'web_seed_001',
+  patientId: 'patient_101',
+  mockEvents: [
+    {
+      eventId: 'evt_201',
+      category: 'consultation',
+      title: 'General Practitioner Consultation',
+      timestamp: '2026-07-25T14:30:00Z',
+    },
+    {
+      eventId: 'evt_202',
+      category: 'vitals',
+      title: 'Blood Pressure & Heart Rate Monitoring',
+      timestamp: '2026-07-25T15:00:00Z',
+    },
+  ],
+};

--- a/docs/patient-records-chart-timeline-fixtures-spec.md
+++ b/docs/patient-records-chart-timeline-fixtures-spec.md
@@ -1,0 +1,12 @@
+# Patient Records Chart Timeline Test Fixtures Specification
+
+This document outlines the test fixture structures and seed data payloads for patient chart timeline testing in web and API modules.
+
+## Fixture Layout
+
+1. **Web & API Seeds**:
+   - `apps/web/src/fixtures/chart-timeline.fixture.ts`: Web mock timeline events.
+   - `apps/api/src/fixtures/chart-timeline-api.fixture.ts`: API seed data fixture.
+
+2. **Validation Schemas & Interfaces**:
+   - `timelineFixtureSeedSchema` and `TimelineFixtureSeed` defined in `@qyou/shared`.

--- a/packages/shared/src/types/chart-timeline-fixtures.types.ts
+++ b/packages/shared/src/types/chart-timeline-fixtures.types.ts
@@ -1,0 +1,17 @@
+export interface MockTimelineEventItem {
+  eventId: string;
+  category: string;
+  title: string;
+  timestamp: string;
+}
+
+export interface TimelineFixtureSeed {
+  seedId: string;
+  patientId: string;
+  mockEvents: MockTimelineEventItem[];
+}
+
+export interface TimelineTestEnvironment {
+  seedName: string;
+  eventsCount: number;
+}

--- a/packages/shared/src/validation/chart-timeline-fixtures.schemas.ts
+++ b/packages/shared/src/validation/chart-timeline-fixtures.schemas.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+export const mockTimelineEventItemSchema = z.object({
+  eventId: z.string().min(1, 'Event ID is required.'),
+  category: z.string().min(1, 'Category is required.'),
+  title: z.string().min(1, 'Title is required.'),
+  timestamp: z.string().min(1),
+});
+
+export const timelineFixtureSeedSchema = z.object({
+  seedId: z.string().min(1),
+  patientId: z.string().min(1),
+  mockEvents: z.array(mockTimelineEventItemSchema).min(1, 'At least one mock event is required.'),
+});
+
+export type TimelineFixtureSeedInput = z.infer<typeof timelineFixtureSeedSchema>;


### PR DESCRIPTION
Added web and API test fixtures, mock event seeds, and validation schemas for patient chart timeline testing.

Highlights:
- Created mock timeline seeds in apps/web/src/fixtures/chart-timeline.fixture.ts
- Added API seed fixture in apps/api/src/fixtures/chart-timeline-api.fixture.ts
- Defined timelineFixtureSeedSchema & mockTimelineEventItemSchema in @qyou/shared
- Documented timeline test fixture specifications in docs/patient-records-chart-timeline-fixtures-spec.md

closes #886
closes #885
closes #884
closes #883