### PR TITLE
feat(records): patient demographics test fixtures & validation schemas

### DIFF
--- a/apps/api/src/fixtures/patient-demographics-api.fixture.ts
+++ b/apps/api/src/fixtures/patient-demographics-api.fixture.ts
@@ -1,0 +1,20 @@
+import type { DemographicFixtureSeed } from '@qyou/shared';
+
+export const mockApiPatientDemographicsFixture: DemographicFixtureSeed = {
+  seedId: 'demo_seed_api_002',
+  records: [
+    {
+      patientId: 'patient_402',
+      firstName: 'Robert',
+      lastName: 'Smith',
+      dateOfBirth: '1985-11-22',
+      gender: 'male',
+      bloodType: 'A-',
+      emergencyContact: {
+        name: 'Mary Smith',
+        relationship: 'Sister',
+        phoneNumber: '+1-555-0188',
+      },
+    },
+  ],
+};

--- a/apps/web/src/fixtures/patient-demographics.fixture.ts
+++ b/apps/web/src/fixtures/patient-demographics.fixture.ts
@@ -1,0 +1,20 @@
+import type { DemographicFixtureSeed } from '@qyou/shared';
+
+export const mockWebPatientDemographicsFixture: DemographicFixtureSeed = {
+  seedId: 'demo_seed_web_001',
+  records: [
+    {
+      patientId: 'patient_401',
+      firstName: 'Jane',
+      lastName: 'Doe',
+      dateOfBirth: '1992-05-14',
+      gender: 'female',
+      bloodType: 'O+',
+      emergencyContact: {
+        name: 'John Doe',
+        relationship: 'Spouse',
+        phoneNumber: '+1-555-0199',
+      },
+    },
+  ],
+};

--- a/docs/patient-records-demographics-fixtures-spec.md
+++ b/docs/patient-records-demographics-fixtures-spec.md
@@ -1,0 +1,12 @@
+# Patient Records Demographics Test Fixtures Specification
+
+This document details the test fixture specifications for patient demographic details, emergency contacts, and blood type attributes in web and API apps.
+
+## Fixtures Layout
+
+1. **Web & API Fixture Seeds**:
+   - `apps/web/src/fixtures/patient-demographics.fixture.ts`: Web mock demographics fixture.
+   - `apps/api/src/fixtures/patient-demographics-api.fixture.ts`: API test seed data.
+
+2. **Validation Schemas & Interfaces**:
+   - `patientDemographicRecordSchema` and `PatientDemographicRecord` defined in `@qyou/shared`.

--- a/packages/shared/src/types/patient-demographics-fixtures.types.ts
+++ b/packages/shared/src/types/patient-demographics-fixtures.types.ts
@@ -1,0 +1,22 @@
+export type GenderCategory = 'male' | 'female' | 'non_binary' | 'other' | 'prefer_not_to_say';
+
+export interface EmergencyContactItem {
+  name: string;
+  relationship: string;
+  phoneNumber: string;
+}
+
+export interface PatientDemographicRecord {
+  patientId: string;
+  firstName: string;
+  lastName: string;
+  dateOfBirth: string;
+  gender: GenderCategory;
+  bloodType?: string;
+  emergencyContact: EmergencyContactItem;
+}
+
+export interface DemographicFixtureSeed {
+  seedId: string;
+  records: PatientDemographicRecord[];
+}

--- a/packages/shared/src/validation/patient-demographics-fixtures.schemas.ts
+++ b/packages/shared/src/validation/patient-demographics-fixtures.schemas.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+
+export const genderCategorySchema = z.enum(['male', 'female', 'non_binary', 'other', 'prefer_not_to_say']);
+
+export const emergencyContactItemSchema = z.object({
+  name: z.string().min(1, 'Contact name is required.'),
+  relationship: z.string().min(1, 'Relationship is required.'),
+  phoneNumber: z.string().min(5, 'Phone number is required.'),
+});
+
+export const patientDemographicRecordSchema = z.object({
+  patientId: z.string().min(1, 'Patient ID is required.'),
+  firstName: z.string().min(1, 'First name is required.'),
+  lastName: z.string().min(1, 'Last name is required.'),
+  dateOfBirth: z.string().min(1),
+  gender: genderCategorySchema,
+  bloodType: z.string().optional(),
+  emergencyContact: emergencyContactItemSchema,
+});
+
+export type PatientDemographicRecordInput = z.infer<typeof patientDemographicRecordSchema>;


### PR DESCRIPTION
Added web & API test data fixtures, emergency contact schemas, and validation rules for patient demographics.

Summary:
- Built mock web demographics fixture in apps/web/src/fixtures/patient-demographics.fixture.ts
- Added API seed fixture in apps/api/src/fixtures/patient-demographics-api.fixture.ts
- Defined patientDemographicRecordSchema & emergencyContactItemSchema in @qyou/shared
- Documented demographics test specifications in docs/patient-records-demographics-fixtures-spec.md

close #862
close #861
close #860
close #859