### PR TITLE
feat(records): patient consent and privacy test fixtures & Zod schemas

### DIFF
--- a/apps/api/src/fixtures/patient-consent-api.fixture.ts
+++ b/apps/api/src/fixtures/patient-consent-api.fixture.ts
@@ -1,0 +1,15 @@
+import type { ConsentFixtureSeed } from '@qyou/shared';
+
+export const mockApiPatientConsentFixture: ConsentFixtureSeed = {
+  seedId: 'consent_seed_api_002',
+  consents: [
+    {
+      consentId: 'cns_201',
+      patientId: 'patient_502',
+      scope: 'data_sharing',
+      status: 'granted',
+      grantedAt: '2026-07-25T09:30:00Z',
+      expiresAt: '2027-07-25T09:30:00Z',
+    },
+  ],
+};

--- a/apps/web/src/fixtures/patient-consent.fixture.ts
+++ b/apps/web/src/fixtures/patient-consent.fixture.ts
@@ -1,0 +1,20 @@
+import type { ConsentFixtureSeed } from '@qyou/shared';
+
+export const mockWebPatientConsentFixture: ConsentFixtureSeed = {
+  seedId: 'consent_seed_web_001',
+  consents: [
+    {
+      consentId: 'cns_101',
+      patientId: 'patient_501',
+      scope: 'medical_history',
+      status: 'granted',
+      grantedAt: '2026-07-25T08:00:00Z',
+    },
+    {
+      consentId: 'cns_102',
+      patientId: 'patient_501',
+      scope: 'marketing',
+      status: 'revoked',
+    },
+  ],
+};

--- a/docs/patient-records-consent-privacy-fixtures-spec.md
+++ b/docs/patient-records-consent-privacy-fixtures-spec.md
@@ -1,0 +1,12 @@
+# Patient Records Consent & Privacy Test Fixtures Specification
+
+This document details the test fixture specifications for patient consent records, privacy preference scopes, and expiration rules in LumenHealth.
+
+## Fixture Layout
+
+1. **Web & API Seeds**:
+   - `apps/web/src/fixtures/patient-consent.fixture.ts`: Web consent test fixture.
+   - `apps/api/src/fixtures/patient-consent-api.fixture.ts`: API seed data fixture.
+
+2. **Validation Schemas & Interfaces**:
+   - `patientConsentRecordSchema` and `PatientConsentRecord` defined in `@qyou/shared`.

--- a/packages/shared/src/types/consent-privacy-fixtures.types.ts
+++ b/packages/shared/src/types/consent-privacy-fixtures.types.ts
@@ -1,0 +1,17 @@
+export type ConsentStatus = 'granted' | 'revoked' | 'pending';
+
+export type ConsentScopeOption = 'medical_history' | 'data_sharing' | 'research_analytics' | 'marketing';
+
+export interface PatientConsentRecord {
+  consentId: string;
+  patientId: string;
+  scope: ConsentScopeOption;
+  status: ConsentStatus;
+  grantedAt?: string;
+  expiresAt?: string;
+}
+
+export interface ConsentFixtureSeed {
+  seedId: string;
+  consents: PatientConsentRecord[];
+}

--- a/packages/shared/src/validation/consent-privacy-fixtures.schemas.ts
+++ b/packages/shared/src/validation/consent-privacy-fixtures.schemas.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+export const consentStatusSchema = z.enum(['granted', 'revoked', 'pending']);
+export const consentScopeOptionSchema = z.enum(['medical_history', 'data_sharing', 'research_analytics', 'marketing']);
+
+export const patientConsentRecordSchema = z.object({
+  consentId: z.string().min(1, 'Consent ID is required.'),
+  patientId: z.string().min(1, 'Patient ID is required.'),
+  scope: consentScopeOptionSchema,
+  status: consentStatusSchema,
+  grantedAt: z.string().optional(),
+  expiresAt: z.string().optional(),
+});
+
+export type PatientConsentRecordInput = z.infer<typeof patientConsentRecordSchema>;


### PR DESCRIPTION
Implemented patient consent & privacy preference test fixtures, scope option models, and validation schemas.

Summary of changes:
- Created mock consent seeds in apps/web/src/fixtures/patient-consent.fixture.ts
- Added API seed fixture in apps/api/src/fixtures/patient-consent-api.fixture.ts
- Defined patientConsentRecordSchema & consentScopeOptionSchema in @qyou/shared
- Documented consent test specifications in docs/patient-records-consent-privacy-fixtures-spec.md

close #914
close #913
close #912
close #911