### PR TITLE
feat(records): patient consent data model & privacy policy card UI

### DIFF
--- a/apps/api/src/modules/consent/repositories/in-memory-consent.repository.ts
+++ b/apps/api/src/modules/consent/repositories/in-memory-consent.repository.ts
@@ -1,0 +1,14 @@
+import type { PrivacySettingRule } from '@qyou/shared';
+
+export class InMemoryConsentRepository {
+  private readonly rules: Map<string, PrivacySettingRule> = new Map();
+
+  public async savePrivacySettingRule(rule: PrivacySettingRule): Promise<PrivacySettingRule> {
+    this.rules.set(rule.patientId, rule);
+    return rule;
+  }
+
+  public async getPrivacySettingRule(patientId: string): Promise<PrivacySettingRule | null> {
+    return this.rules.get(patientId) ?? null;
+  }
+}

--- a/apps/web/src/components/ConsentPrivacyPolicyCard.tsx
+++ b/apps/web/src/components/ConsentPrivacyPolicyCard.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+interface ConsentPrivacyPolicyCardProps {
+  policyVersion?: string;
+  allowSharing?: boolean;
+}
+
+export function ConsentPrivacyPolicyCard({
+  policyVersion = 'v1.0.0',
+  allowSharing = false,
+}: ConsentPrivacyPolicyCardProps) {
+  return (
+    <div style={{ padding: '16px', background: '#faf5ff', border: '1px solid #e9d5ff', borderRadius: '8px' }}>
+      <h4 style={{ margin: '0 0 8px 0', color: '#6b21a8' }}>Privacy Policy {policyVersion}</h4>
+      <div style={{ fontSize: '13px', color: '#581c87' }}>
+        Third-Party Data Sharing: <strong>{allowSharing ? 'Enabled' : 'Disabled'}</strong>
+      </div>
+    </div>
+  );
+}

--- a/docs/patient-records-consent-data-model-spec.md
+++ b/docs/patient-records-consent-data-model-spec.md
@@ -1,0 +1,12 @@
+# Patient Records Consent Data Model Specification
+
+This document details the data models, repository abstractions, and Zod schemas for patient consent rules and data-sharing preferences in LumenHealth.
+
+## Data Models & Repositories
+
+1. **Repository & UI Card**:
+   - `apps/api/src/modules/consent/repositories/in-memory-consent.repository.ts`: Repository managing in-memory storage of privacy rules.
+   - `ConsentPrivacyPolicyCard`: React component displaying policy versioning and data sharing toggles.
+
+2. **Validation Schemas & Interfaces**:
+   - `privacySettingRuleSchema` and `PrivacySettingRule` defined in `@qyou/shared`.

--- a/packages/shared/src/types/consent-data-model.types.ts
+++ b/packages/shared/src/types/consent-data-model.types.ts
@@ -1,0 +1,19 @@
+export interface DataSharingPermission {
+  thirdPartyId: string;
+  isAllowed: boolean;
+  grantedUntil?: string;
+}
+
+export interface PrivacySettingRule {
+  ruleId: string;
+  patientId: string;
+  allowThirdPartySharing: boolean;
+  permissions: DataSharingPermission[];
+  policyVersion: string;
+}
+
+export interface ConsentPolicyVersion {
+  version: string;
+  effectiveDate: string;
+  summaryText: string;
+}

--- a/packages/shared/src/validation/consent-data-model.schemas.ts
+++ b/packages/shared/src/validation/consent-data-model.schemas.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+export const dataSharingPermissionSchema = z.object({
+  thirdPartyId: z.string().min(1, 'Third party ID is required.'),
+  isAllowed: z.boolean(),
+  grantedUntil: z.string().optional(),
+});
+
+export const privacySettingRuleSchema = z.object({
+  ruleId: z.string().min(1, 'Rule ID is required.'),
+  patientId: z.string().min(1, 'Patient ID is required.'),
+  allowThirdPartySharing: z.boolean().default(false),
+  permissions: z.array(dataSharingPermissionSchema).default([]),
+  policyVersion: z.string().default('v1.0.0'),
+});
+
+export type PrivacySettingRuleInput = z.infer<typeof privacySettingRuleSchema>;
+export type DataSharingPermissionInput = z.infer<typeof dataSharingPermissionSchema>;


### PR DESCRIPTION
Refined the patient consent data model, privacy setting rules, and repository abstractions.

Overview:
- Built InMemoryConsentRepository in apps/api for storing privacy setting rules
- Added ConsentPrivacyPolicyCard React component in apps/web/src/components
- Defined privacySettingRuleSchema & dataSharingPermissionSchema in @qyou/shared
- Formulated data model specifications in docs/patient-records-consent-data-model-spec.md

close #890
close #889
close #888
close #887