### PR TITLE
feat(records): patient chart timeline data model & clinical event node repository

### DIFF
--- a/apps/api/src/modules/records/repositories/in-memory-timeline.repository.ts
+++ b/apps/api/src/modules/records/repositories/in-memory-timeline.repository.ts
@@ -1,0 +1,16 @@
+import type { ClinicalEventNode } from '@qyou/shared';
+
+export class InMemoryTimelineRepository {
+  private readonly nodes: Map<string, ClinicalEventNode[]> = new Map();
+
+  public async saveNode(node: ClinicalEventNode): Promise<ClinicalEventNode> {
+    const list = this.nodes.get(node.patientId) ?? [];
+    list.push(node);
+    this.nodes.set(node.patientId, list);
+    return node;
+  }
+
+  public async getNodesByPatient(patientId: string): Promise<ClinicalEventNode[]> {
+    return this.nodes.get(patientId) ?? [];
+  }
+}

--- a/apps/web/src/components/ChartTimelineNodeCard.tsx
+++ b/apps/web/src/components/ChartTimelineNodeCard.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+interface ChartTimelineNodeCardProps {
+  heading?: string;
+  eventType?: string;
+  recordedAt?: string;
+}
+
+export function ChartTimelineNodeCard({
+  heading = 'Laboratory Result Recorded',
+  eventType = 'lab_test',
+  recordedAt = '2026-07-25',
+}: ChartTimelineNodeCardProps) {
+  return (
+    <div style={{ padding: '12px', border: '1px solid #cbd5e1', borderRadius: '6px', background: '#ffffff', marginBottom: '8px' }}>
+      <div style={{ fontWeight: 'bold', color: '#1e293b' }}>{heading}</div>
+      <div style={{ fontSize: '12px', color: '#64748b', marginTop: '4px' }}>
+        Type: {eventType} | Date: {recordedAt}
+      </div>
+    </div>
+  );
+}

--- a/docs/patient-records-chart-timeline-model-spec.md
+++ b/docs/patient-records-chart-timeline-model-spec.md
@@ -1,0 +1,12 @@
+# Patient Records Chart Timeline Model Specification
+
+This document outlines the data model structures, repository storage abstractions, and node schemas for patient chart timeline events in LumenHealth.
+
+## Components & Modules
+
+1. **Repository & UI Component**:
+   - `apps/api/src/modules/records/repositories/in-memory-timeline.repository.ts`: Repository storing clinical event nodes.
+   - `ChartTimelineNodeCard`: React UI card rendering clinical event node attributes.
+
+2. **Validation Schemas & Interfaces**:
+   - `clinicalEventNodeSchema` and `ClinicalEventNode` defined in `@qyou/shared`.

--- a/packages/shared/src/types/chart-timeline-model.types.ts
+++ b/packages/shared/src/types/chart-timeline-model.types.ts
@@ -1,0 +1,19 @@
+export interface EventAttachmentRef {
+  attachmentId: string;
+  label: string;
+  url: string;
+}
+
+export interface ClinicalEventNode {
+  nodeId: string;
+  patientId: string;
+  eventType: string;
+  heading: string;
+  recordedAt: string;
+  attachments?: EventAttachmentRef[];
+}
+
+export interface TimelineChronologyConfig {
+  sortOrder: 'asc' | 'desc';
+  groupByMonth: boolean;
+}

--- a/packages/shared/src/validation/chart-timeline-model.schemas.ts
+++ b/packages/shared/src/validation/chart-timeline-model.schemas.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+export const eventAttachmentRefSchema = z.object({
+  attachmentId: z.string().min(1, 'Attachment ID is required.'),
+  label: z.string().min(1, 'Label is required.'),
+  url: z.string().min(1, 'URL is required.'),
+});
+
+export const clinicalEventNodeSchema = z.object({
+  nodeId: z.string().min(1, 'Node ID is required.'),
+  patientId: z.string().min(1, 'Patient ID is required.'),
+  eventType: z.string().min(1, 'Event type is required.'),
+  heading: z.string().min(1, 'Heading is required.'),
+  recordedAt: z.string().min(1),
+  attachments: z.array(eventAttachmentRefSchema).optional(),
+});
+
+export type ClinicalEventNodeInput = z.infer<typeof clinicalEventNodeSchema>;


### PR DESCRIPTION
Refined the patient chart timeline data model, clinical event nodes, and repository abstractions.

Key highlights:
- Created InMemoryTimelineRepository in apps/api for storing clinical event node records
- Added ChartTimelineNodeCard React component in apps/web/src/components
- Defined clinicalEventNodeSchema & eventAttachmentRefSchema in @qyou/shared
- Documented timeline model specifications in docs/patient-records-chart-timeline-model-spec.md

Fixes #866
Fixes #865
Fixes #864
Fixes #863