### PR TITLE
feat(records): patient consent evaluation service & client validation helpers

### DIFF
--- a/apps/api/src/modules/consent/services/consent-evaluator.service.ts
+++ b/apps/api/src/modules/consent/services/consent-evaluator.service.ts
@@ -1,0 +1,22 @@
+import {
+  privacyConsentPolicySchema,
+  type ConsentCheckResult,
+  type PrivacyConsentPolicyInput,
+} from '@qyou/shared';
+
+export class ConsentEvaluatorService {
+  public evaluateConsent(policy: PrivacyConsentPolicyInput): ConsentCheckResult {
+    const validated = privacyConsentPolicySchema.parse(policy);
+    const now = new Date();
+
+    if (!validated.isGranted) {
+      return { isPermitted: false, reason: 'Consent revoked or not granted.', evaluatedAt: now.toISOString() };
+    }
+
+    if (validated.expiresAt && new Date(validated.expiresAt) < now) {
+      return { isPermitted: false, reason: 'Consent expired.', evaluatedAt: now.toISOString() };
+    }
+
+    return { isPermitted: true, evaluatedAt: now.toISOString() };
+  }
+}

--- a/apps/web/src/lib/patient-consent-evaluator-client.ts
+++ b/apps/web/src/lib/patient-consent-evaluator-client.ts
@@ -1,0 +1,7 @@
+import type { ConsentCheckResult, PrivacyConsentPolicyInput } from '@qyou/shared';
+
+export function isPatientConsentActive(policy: PrivacyConsentPolicyInput): boolean {
+  if (!policy.isGranted) return false;
+  if (policy.expiresAt && new Date(policy.expiresAt) < new Date()) return false;
+  return true;
+}

--- a/docs/patient-records-consent-evaluator-spec.md
+++ b/docs/patient-records-consent-evaluator-spec.md
@@ -1,0 +1,14 @@
+# Patient Records Consent Evaluator Specification
+
+This document details the consent evaluation logic, validity check services, and web client helpers in LumenHealth.
+
+## Components & Modules
+
+1. **Evaluator Service**:
+   - `apps/api/src/modules/consent/services/consent-evaluator.service.ts`: `ConsentEvaluatorService` performing expiration & permission checks.
+
+2. **Web Client Helper**:
+   - `apps/web/src/lib/patient-consent-evaluator-client.ts`: Utility function `isPatientConsentActive`.
+
+3. **Validation Schemas & Interfaces**:
+   - `privacyConsentPolicySchema` and `ConsentCheckResult` defined in `@qyou/shared`.

--- a/packages/shared/src/types/consent-service-handler.types.ts
+++ b/packages/shared/src/types/consent-service-handler.types.ts
@@ -1,0 +1,12 @@
+export interface PrivacyConsentPolicy {
+  patientId: string;
+  scope: string;
+  isGranted: boolean;
+  expiresAt?: string;
+}
+
+export interface ConsentCheckResult {
+  isPermitted: boolean;
+  reason?: string;
+  evaluatedAt: string;
+}

--- a/packages/shared/src/validation/consent-service-handler.schemas.ts
+++ b/packages/shared/src/validation/consent-service-handler.schemas.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+export const privacyConsentPolicySchema = z.object({
+  patientId: z.string().min(1, 'Patient ID is required.'),
+  scope: z.string().min(1, 'Scope is required.'),
+  isGranted: z.boolean(),
+  expiresAt: z.string().optional(),
+});
+
+export const consentCheckResultSchema = z.object({
+  isPermitted: z.boolean(),
+  reason: z.string().optional(),
+  evaluatedAt: z.string().min(1),
+});
+
+export type PrivacyConsentPolicyInput = z.infer<typeof privacyConsentPolicySchema>;
+export type ConsentCheckResultInput = z.infer<typeof consentCheckResultSchema>;


### PR DESCRIPTION
Implemented the consent evaluator service, validity check logic, and web client helper utilities.

Overview of changes:
- Created ConsentEvaluatorService in apps/api for checking expiration timestamps and permission status
- Added isPatientConsentActive helper function in apps/web/src/lib
- Defined privacyConsentPolicySchema & consentCheckResultSchema in @qyou/shared
- Documented evaluation specs in docs/patient-records-consent-evaluator-spec.md

close #898
close #897
close #896
close #895