### PR TITLE
feat(records): patient privacy preference web and API test fixtures & Zod schemas

### DIFF
--- a/apps/api/src/fixtures/patient-privacy-audit-api.fixture.ts
+++ b/apps/api/src/fixtures/patient-privacy-audit-api.fixture.ts
@@ -1,0 +1,11 @@
+import type { WebConsentTestFixture } from '@qyou/shared';
+
+export const mockApiPrivacyAuditFixture: WebConsentTestFixture = {
+  fixtureId: 'priv_fix_api_002',
+  preferences: {
+    patientId: 'patient_602',
+    analyticsSharing: false,
+    marketingOptIn: false,
+    medicalResearchOptIn: false,
+  },
+};

--- a/apps/web/src/fixtures/patient-privacy-preferences.fixture.ts
+++ b/apps/web/src/fixtures/patient-privacy-preferences.fixture.ts
@@ -1,0 +1,11 @@
+import type { WebConsentTestFixture } from '@qyou/shared';
+
+export const mockWebPrivacyPreferencesFixture: WebConsentTestFixture = {
+  fixtureId: 'priv_fix_web_001',
+  preferences: {
+    patientId: 'patient_601',
+    analyticsSharing: true,
+    marketingOptIn: false,
+    medicalResearchOptIn: true,
+  },
+};

--- a/docs/patient-records-consent-web-api-fixtures-spec.md
+++ b/docs/patient-records-consent-web-api-fixtures-spec.md
@@ -1,0 +1,12 @@
+# Patient Records Consent Web & API Test Fixtures Specification
+
+This document details the test fixture specifications for web & API privacy preferences, opt-in/opt-out toggles, and test assertions in LumenHealth.
+
+## Fixture Layout
+
+1. **Web & API Test Fixtures**:
+   - `apps/web/src/fixtures/patient-privacy-preferences.fixture.ts`: Web mock privacy preferences fixture.
+   - `apps/api/src/fixtures/patient-privacy-audit-api.fixture.ts`: API seed data fixture.
+
+2. **Validation Schemas & Interfaces**:
+   - `mockPrivacyPreferencePayloadSchema` and `MockPrivacyPreferencePayload` defined in `@qyou/shared`.

--- a/packages/shared/src/types/consent-web-fixtures.types.ts
+++ b/packages/shared/src/types/consent-web-fixtures.types.ts
@@ -1,0 +1,16 @@
+export interface MockPrivacyPreferencePayload {
+  patientId: string;
+  analyticsSharing: boolean;
+  marketingOptIn: boolean;
+  medicalResearchOptIn: boolean;
+}
+
+export interface WebConsentTestFixture {
+  fixtureId: string;
+  preferences: MockPrivacyPreferencePayload;
+}
+
+export interface ConsentAssertionResult {
+  passed: boolean;
+  missingScopes: string[];
+}

--- a/packages/shared/src/validation/consent-web-fixtures.schemas.ts
+++ b/packages/shared/src/validation/consent-web-fixtures.schemas.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+export const mockPrivacyPreferencePayloadSchema = z.object({
+  patientId: z.string().min(1, 'Patient ID is required.'),
+  analyticsSharing: z.boolean(),
+  marketingOptIn: z.boolean(),
+  medicalResearchOptIn: z.boolean(),
+});
+
+export const webConsentTestFixtureSchema = z.object({
+  fixtureId: z.string().min(1),
+  preferences: mockPrivacyPreferencePayloadSchema,
+});
+
+export type MockPrivacyPreferencePayloadInput = z.infer<typeof mockPrivacyPreferencePayloadSchema>;
+export type WebConsentTestFixtureInput = z.infer<typeof webConsentTestFixtureSchema>;


### PR DESCRIPTION
Added web and API test data fixtures, opt-in/opt-out schemas, and validation rules for patient privacy preferences.

Summary:
- Built mock web privacy preference seeds in apps/web/src/fixtures/patient-privacy-preferences.fixture.ts
- Created API privacy audit seed in apps/api/src/fixtures/patient-privacy-audit-api.fixture.ts
- Defined mockPrivacyPreferencePayloadSchema & webConsentTestFixtureSchema in @qyou/shared
- Documented privacy fixture specifications in docs/patient-records-consent-web-api-fixtures-spec.md

close #923
close #910
close #909
close #908